### PR TITLE
Update cgdb.texinfo

### DIFF
--- a/doc/cgdb.texinfo
+++ b/doc/cgdb.texinfo
@@ -686,7 +686,7 @@ Searches wrap around the end of file.  The default is on.
 @itemx :continue
 Send a continue command to GDB.
 
-@itemx :down
+@item :down
 Send a down command to GDB.
 
 @item :e
@@ -752,7 +752,7 @@ Send a step command to GDB.
 @item :syntax
 Turn the syntax on or off.
 
-@itemx :up
+@item :up
 Send an up command to GDB.
 
 @item :map @var{lhs} @var{rhs}


### PR DESCRIPTION
On texinfo 5.1, cgdb.texinfo failed to build saying that itemx needs to be preceded by and item. Changing the itemx to item fixes this.
