### PR TITLE
Check to make certain the debugger exist before forking

### DIFF
--- a/lib/util/fork_util.c
+++ b/lib/util/fork_util.c
@@ -224,6 +224,12 @@ int invoke_debugger(const char *path,
 
     local_argv[j] = NULL;
 
+    if (fs_util_file_exists_in_path(local_argv[0]) == -1) {
+        logger_write_pos(logger, __FILE__, __LINE__,
+                         "Debugger \"%s\" not found", local_argv[0]);
+        pty_free_memory(slavename, masterfd, argc, local_argv);
+        return -1;
+    }
     /* Fork into two processes with a shared pty pipe */
     pid = pty_fork(&masterfd, slavename, SLAVE_SIZE, NULL, NULL);
 

--- a/lib/util/fs_util.c
+++ b/lib/util/fs_util.c
@@ -154,3 +154,33 @@ void fs_util_get_path(const char *base, const char *name, char *path)
     strncpy(path, dir, strlen(dir) + 1);
 #endif
 }
+
+int fs_util_file_exists_in_path(char * filePath)
+{
+    struct stat buff;
+    char * tok, *local_pathStr;
+    char testPath[1024];
+    int result = -1;
+    char *pathStr = getenv("PATH");
+    local_pathStr = malloc(strlen(pathStr) + 1);
+    strcpy(local_pathStr, pathStr);
+    
+    if (stat(filePath, &buff) >= 0)
+    {
+        free(local_pathStr);
+        return 0;
+    }
+    /* Check all directories in path*/
+    tok = strtok(local_pathStr, ":");
+    while (tok != NULL)
+    {
+        sprintf(testPath, "%s/%s", tok, filePath);
+        if (stat(testPath, &buff) >= 0) {
+            result = 0;
+            break;
+        }
+        tok = strtok(NULL, ":");
+    }
+    free(local_pathStr);
+    return result;
+}

--- a/lib/util/fs_util.h
+++ b/lib/util/fs_util.h
@@ -69,4 +69,11 @@ int fs_util_create_dir_in_base(const char *base, const char *dirname);
  */
 void fs_util_get_path(const char *base, const char *name, char *path);
 
+/* fs_util_file_exists_in path:
+ * ----------------------------
+ *
+ * Checks if the file exists in any known location (absolute path
+ * and paths stored in $PATH.
+ */
+int fs_util_file_exists_in_path(char * filePath);
 #endif


### PR DESCRIPTION
When the debugger is not found cgdb exits silently without any error or log message. This can easily be verified by running
`cgdb -d no-gdb-at-all`

This pull request adds a check to verify that the debugger executable exists (locally as well as in path) using `stat()`.
