### PR TITLE
UTF-8 Fix

### DIFF
--- a/cgdb/scroller.c
+++ b/cgdb/scroller.c
@@ -93,7 +93,7 @@ static char *parse(struct scroller *scr, const char *orig, const char *buf)
                 break;
                 /* Default case -> Only keep printable characters */
             default:
-                if (isprint((int) buf[j])) {
+                if (!iscntrl((int) buf[j])) {
                     rv[i] = buf[j];
                     i++;
                 }

--- a/configure.init
+++ b/configure.init
@@ -161,14 +161,21 @@ dnl Part 1: Detecting ncurses/curses
 dnl If the user want ncurses, Try to find it and add it to the linking library.
 if test "$use_ncurses_library" = "yes"; then
         AC_CHECK_LIB(ncurses, initscr,
-            [AC_DEFINE(HAVE_NCURSES, 1, ncurses library)],
+            [AC_DEFINE(HAVE_NCURSES, ["yes"], ncurses library)])
+        AC_CHECK_LIB(ncursesw, initscr,
+            [AC_DEFINE(HAVE_NCURSES, ["yes"], ncursesw library)])
+        if test "$ac_cv_lib_ncursesw_initscr" = "yes"; then
+	    curses_lib_name="ncursesw"
+        elif test "$ac_cv_lib_ncurses_initscr" = "yes"; then
+	    curses_lib_name="ncurses"
+        else
             AC_MSG_ERROR([cgdb needs ncurses/curses to build. ncurses is strongly recommended.
-    If your system does not have ncurses get it!
-    If that is not an option try 'configure --with-curses.'
-    You can try --with-ncurses=/foo/ncurses to tell configure where ncurses is.]))
-	curses_lib_name="ncurses"
-fi
+            If your system does not have ncurses get it!
+            If that is not an option try 'configure --with-curses.'
+            You can try --with-ncurses=/foo/ncurses to tell configure where ncurses is.])
+        fi
 
+fi
 dnl If the user want curses, Warn them that cgdb does not run perfect against it.
 if test "$use_ncurses_library" = "no"; then
         AC_MSG_WARN([ *****************************************************


### PR DESCRIPTION
This pull-request incorporates (cherry-picking) [@forslund changes](https://github.com/cgdb/cgdb/pull/27) to add UTF-8 support by linking to ncursesw. It also removes one commit related to warning messages from his pull-request, since I haven't experienced such warnings, and see no reason for them to show up because of ncursesw usage.

It extends forslund changes for UTF-8 support by replacing use of `isprint` by `!iscntrl` for non-printable character's exclusion, which allows a wider range of characters to be displayed, including utf8 characters, in other windows beyond the source window.
