### PR TITLE
Fixed a bug that all map and imap mappings will append a \n to the command

### DIFF
--- a/cgdb/command_lexer.l
+++ b/cgdb/command_lexer.l
@@ -55,7 +55,7 @@ const char * get_token( void )
 <MAP_ID>
 {
 " "     { /* ignore white space */ }
-[^ ]+   { return IDENTIFIER; }
+[^ \r\n]+   { return IDENTIFIER; }
 .       { /* ignore bad-characters */ }
 }
 


### PR DESCRIPTION
cgdb will append a \n to the end of the command mapping. That's inconvenient especially for imap, since all the mapping command will be send to gdb.
