### PR TITLE
Added 'until' command to CGDB mode

### DIFF
--- a/cgdb/cgdbrc.c
+++ b/cgdb/cgdbrc.c
@@ -202,6 +202,8 @@ COMMANDS commands[] = {
     /* kill         */ {"k", command_do_tgdbcommand, TGDB_KILL},
     /* step         */ {"step", command_do_tgdbcommand, TGDB_STEP},
     /* step         */ {"s", command_do_tgdbcommand, TGDB_STEP},
+    /* until        */ {"until", command_do_tgdbcommand, TGDB_UNTIL},
+    /* until        */ {"u", command_do_tgdbcommand, TGDB_UNTIL},
     /* start        */ {"start", command_do_tgdbcommand, TGDB_START},
     /* up               */ {"up", command_do_tgdbcommand, TGDB_UP},
 };

--- a/lib/tgdb/annotate-two/a2-tgdb.c
+++ b/lib/tgdb/annotate-two/a2-tgdb.c
@@ -392,6 +392,9 @@ char *a2_return_client_command(void *ctx, enum tgdb_command_type c)
         case TGDB_STEP:
             ret = "step";
             break;
+        case TGDB_UNTIL:
+            ret = "until";
+            break;
         case TGDB_UP:
             ret = "up";
             break;

--- a/lib/tgdb/tgdb-base/tgdb_types.h
+++ b/lib/tgdb/tgdb-base/tgdb_types.h
@@ -105,6 +105,13 @@ extern "C" {
     /** This will instruct TGDB to tell the debugger to step.  */
         TGDB_STEP,
 
+    /** 
+     * This will instruct TGDB to tell the debugger to continue running until
+     * a source line past the current line.  This is used to avoid single stepping
+     * through loops.
+     */
+        TGDB_UNTIL,
+
     /** This will instruct TGDB to tell the debugger to go up a frame.  */
         TGDB_UP,
 


### PR DESCRIPTION
This command is useful because it allows you to easily skip having to single step through loops in your code.

This fixes issue #29 .
