### PR TITLE
Remove explicit path argument from AC_CHECK_PROG.

### DIFF
--- a/configure.init
+++ b/configure.init
@@ -88,8 +88,8 @@ AC_CHECK_FUNC([strerror],,AC_MSG_ERROR([CGDB requires strerror to build.]))
 AC_CHECK_FUNC([openpty],[AC_DEFINE(HAVE_OPENPTY, 1, [Define to 1 if you have the openpty function])],)
 
 dnl program checks
-AC_CHECK_PROG([HAS_MAKEINFO], [makeinfo], [yes], [no], [path =$PATH])
-AC_CHECK_PROG([HAS_HELP2MAN], [help2man], [yes], [no], [path =$PATH])
+AC_CHECK_PROG([HAS_MAKEINFO], [makeinfo], [yes], [no])
+AC_CHECK_PROG([HAS_HELP2MAN], [help2man], [yes], [no])
 dnl Default variables
 dnl If ncurses is yes after arguments, than use ncurses. Otherwise, use curses
 opt_with_readline_prefix=no


### PR DESCRIPTION
Setting AC_CHECK_PROG like in configure.init results in expression `for as_dir in path =$PATH` .

As you can see it means that before the first path from $PATH there is an equal sign added. Since this is an incorrect path (like "=/bin") no executable could be found there. If you have a program residing in first path from the $PATH variable it won't be found.
