### PR TITLE
git checkouts require autogen.sh in INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -25,6 +25,8 @@ it or regenerate `configure' using a newer version of `autoconf'.
 
 The simplest way to compile this package is:
 
+NOTE if building from a git checkout, `sh autogen.sh` needs to be ran first.
+
   1. `cd' to the directory containing the package's source code and type
      `./configure' to configure the package for your system.  If you're
      using `csh' on an old version of System V, you might need to type


### PR DESCRIPTION
http://cgdb.github.io/ mentions that autogen is required when building from git. INSTALL file needs a note too.
