### PR TITLE
Set breakpoint using full file path

### DIFF
--- a/cgdb/interface.cpp
+++ b/cgdb/interface.cpp
@@ -1035,11 +1035,7 @@ toggle_breakpoint(struct sviewer *sview, enum tgdb_breakpoint_action t)
         return 0;
 
     line = sview->cur->sel_line;
-
-    /* Get filename (strip path off -- GDB is dumb) */
-    path = strrchr(sview->cur->path, '/') + 1;
-    if (path == (char *)NULL + 1)
-        path = sview->cur->path;
+    path = sview->cur->path;
 
     /* delete an existing breakpoint */
     if (sview->cur->lflags[line].breakpt)


### PR DESCRIPTION
Some projects can have more than one file with the same name (for example
icmp.c in Linux).

Signed-off-by: Slawomir Stepien sst@poczta.fm
