### PR TITLE
Fix several -Wswitch, -Wunused-variable warnings with gcc v6.2.

### DIFF
--- a/cgdb/highlight_groups.cpp
+++ b/cgdb/highlight_groups.cpp
@@ -580,6 +580,29 @@ hl_groups_get_attr(hl_groups_ptr hl_groups, enum hl_group_kind kind)
             attr = SWIN_A_BOLD | swin_color_pair(
                 hl_get_ansicolor_pair(hl_groups, -1, kind - HLG_BOLD_BLACK));
             return attr;
+        case HLG_TYPE:
+        case HLG_KEYWORD:
+        case HLG_LITERAL:
+        case HLG_COMMENT:
+        case HLG_DIRECTIVE:
+        case HLG_TEXT:
+        case HLG_SEARCH:
+        case HLG_STATUS_BAR:
+        case HLG_EXECUTING_LINE_ARROW:
+        case HLG_SELECTED_LINE_ARROW:
+        case HLG_EXECUTING_LINE_HIGHLIGHT:
+        case HLG_SELECTED_LINE_HIGHLIGHT:
+        case HLG_EXECUTING_LINE_BLOCK:
+        case HLG_SELECTED_LINE_BLOCK:
+        case HLG_ENABLED_BREAKPOINT:
+        case HLG_DISABLED_BREAKPOINT:
+        case HLG_SELECTED_LINE_NUMBER:
+        case HLG_EXECUTING_LINE_NUMBER:
+        case HLG_SCROLL_MODE_STATUS:
+        case HLG_LOGO:
+        case HLG_MARK:
+        case HLG_LAST:
+            break;
     }
 
     if (hl_groups && info) {

--- a/cgdb/sources.cpp
+++ b/cgdb/sources.cpp
@@ -371,6 +371,8 @@ static enum hl_group_kind hlg_from_tokenizer_type(enum tokenizer_type type, cons
         case TOKENIZER_LOGO: return HLG_LOGO;
         case TOKENIZER_COLOR: return hl_get_color_group(tok_data);
     }
+
+    return HLG_TEXT;
 }
 
 static int highlight_node(struct list_node *node)
@@ -817,10 +819,8 @@ int source_display(struct sviewer *sview, int focus, enum win_refresh dorefresh)
     int count;
 
     enum LineDisplayStyle exe_display_style, sel_display_style;
-    int attr = 0;
     int sellineno, exelineno;
     int enabled_bp, disabled_bp;
-    int exe_line_display, sel_line_display;
     int exe_line_display_is_arrow, sel_line_display_is_arrow;
     int exe_arrow_attr, sel_arrow_attr;
     int exe_highlight_attr, sel_highlight_attr;
@@ -828,9 +828,6 @@ int source_display(struct sviewer *sview, int focus, enum win_refresh dorefresh)
     char fmt[16];
     int width, height;
     int focus_attr = focus ? SWIN_A_BOLD : 0;
-    int is_sel_line, is_exe_line;
-    int highlight_tabstop = cgdbrc_get_int(CGDBRC_TABSTOP);
-    const char *cur_line;
     int showmarks = cgdbrc_get_int(CGDBRC_SHOWMARKS);
     int mark_attr;
 
@@ -919,7 +916,6 @@ int source_display(struct sviewer *sview, int focus, enum win_refresh dorefresh)
     for (i = 0; i < height; i++, line++) {
 
         int column_offset = 0;
-        int line_highlight_attr = 0;
         /* Is this the current selected line? */
         int is_sel_line = (line >= 0 && sview->cur->sel_line == line);
         /* Is this the current executing line */

--- a/lib/rline/rline.cpp
+++ b/lib/rline/rline.cpp
@@ -145,8 +145,6 @@ struct rline *rline_initialize(int slavefd, command_cb * command,
 
 static void rline_free_completions()
 {
-    int i;
-
     /* Set and index to 0. */
     sbsetcount(completions_array, 0);
     completions_index = 0;

--- a/lib/tgdb/commands.cpp
+++ b/lib/tgdb/commands.cpp
@@ -346,6 +346,9 @@ static void gdbwire_stream_record_callback(void *context,
             }
             break;
         case DATA_DISASSEMBLE_MODE_QUERY:
+        case VOID_COMMAND:
+        case INFO_SOURCE:
+        case INFO_SOURCES:
             break;
     }
 }
@@ -391,6 +394,8 @@ static void gdbwire_result_record_callback(void *context,
             break;
         case INFO_FRAME:
             commands_process_info_frame(a2, result_record);
+            break;
+        case VOID_COMMAND:
             break;
     }
     commands_set_state(c, VOID_COMMAND);


### PR DESCRIPTION
Also add return in hlg_from_tokenizer_type() when switch values not hit.

Signed-off-by: Michael Sartain <mikesart@gmail.com>