### PR TITLE
Fix a compilation error of variable length array

### DIFF
--- a/cgdb/scroller.cpp
+++ b/cgdb/scroller.cpp
@@ -74,7 +74,7 @@ static char *parse(struct scroller *scr, struct hl_line_attr **attrs,
     int orig_len = strlen(orig);
     int length = MAX(orig_len, scr->current.pos) + buflen +
         (tab_size - 1) * tabcount + 1;
-    char rv[length] = {};
+    char *rv = (char *) cgdb_calloc(length, 1);
     int i, j;
     int debugwincolor = cgdbrc_get_int(CGDBRC_DEBUGWINCOLOR);
     int width, height;
@@ -156,7 +156,7 @@ static char *parse(struct scroller *scr, struct hl_line_attr **attrs,
         rv[width - 1] = 0;
     }
 
-    return strdup(rv);
+    return rv;
 }
 
 static void scroller_set_last_inferior_attr(struct scroller *scr)


### PR DESCRIPTION
This fixes a compilation error due to variable length array.  Since it
is not a standard syntax, this cannot be compiled with other compilers
except for gcc.  So it'd be better to change it to normal syntax.

The problematic change was made by the commit below:

  commit 9587fa248426184099865e5256f3c5f85f47f9ce
  Author: Bob Rossi <bob@brasko.net>
  Date:   Fri Aug 19 19:02:27 2016 -0400

      Fix a memory corruption bug in scroller prompt.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>