### PR TITLE
Fix PRIx64 format string error with compiler by defining __STDC_FORMA…

### DIFF
--- a/cgdb/cgdb.cpp
+++ b/cgdb/cgdb.cpp
@@ -58,6 +58,7 @@
 #include <ctype.h>
 #endif
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 /* Local Includes */

--- a/lib/tgdb/tgdb.cpp
+++ b/lib/tgdb/tgdb.cpp
@@ -23,6 +23,7 @@
 #include <sys/wait.h>
 #endif
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #include "a2-tgdb.h"


### PR DESCRIPTION
…T_MACROS.

Signed-off-by: Renlin Li <lirenlin@gmail.com>