### PR TITLE
Add gdb up and down key bindings

### DIFF
--- a/cgdb/interface.cpp
+++ b/cgdb/interface.cpp
@@ -1421,6 +1421,14 @@ static int cgdb_input(int key, int *last_key)
                                 !regex_direction_last, regex_icase);
             if_draw();
             break;
+        case 'u':
+            /* Issue GDB up command */
+            tgdb_request_run_debugger_command(tgdb, TGDB_UP);
+            return 0;
+        case 'd':
+            /* Issue GDB down command */
+            tgdb_request_run_debugger_command(tgdb, TGDB_DOWN);
+            return 0;
         case CGDB_KEY_CTRL_T:
             if (tgdb_tty_new(tgdb) == -1) {
                 /* Error */


### PR DESCRIPTION
This patch provides key bindings for following gdb commands:

  - 'u' for gdb up command to select upper stack frame
  - 'd' for gdb down command to select lower stack frame

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>