### PR TITLE
Rebind gdb finish command from F7 to F9

### DIFF
--- a/cgdb/interface.cpp
+++ b/cgdb/interface.cpp
@@ -1506,13 +1506,13 @@ static int cgdb_input(int key, int *last_key)
             /* Issue GDB continue command */
             tgdb_request_run_debugger_command(tgdb, TGDB_CONTINUE);
             return 0;
-        case CGDB_KEY_F7:
-            /* Issue GDB finish command */
-            tgdb_request_run_debugger_command(tgdb, TGDB_FINISH);
-            return 0;
         case CGDB_KEY_F8:
             /* Issue GDB next command */
             tgdb_request_run_debugger_command(tgdb, TGDB_NEXT);
+        case CGDB_KEY_F9:
+            /* Issue GDB finish command */
+            tgdb_request_run_debugger_command(tgdb, TGDB_FINISH);
+            return 0;
         case CGDB_KEY_F10:
             /* Issue GDB step command */
             tgdb_request_run_debugger_command(tgdb, TGDB_STEP);


### PR DESCRIPTION
Since gdb finish command is usually needed when step command is used,
it'd be better to place those hotkeys together.  Currently, step command
is placed in F10, so F9 would be a better place for finish command.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>