### PR TITLE
Simple filter for file dialog list via getenv

### DIFF
--- a/cgdb/cgdb.cpp
+++ b/cgdb/cgdb.cpp
@@ -1070,6 +1070,15 @@ static void update_file_position(struct tgdb_response *response)
     }
 }
 
+/* Returns true if string str starts with string prefix, or if prefix is NULL. */
+static bool starts_with(const char *prefix, const char *str)
+{
+  if (!prefix) {
+    return true;
+  }
+  return strncmp(prefix, str, strlen(prefix)) == 0;
+}
+
 /* This is a list of all the source files */
 static void update_source_files(struct tgdb_response *response)
 {
@@ -1095,9 +1104,11 @@ static void update_source_files(struct tgdb_response *response)
                            " No sources available! Was the program compiled with debug?");
     } else {
         int i;
-
+        const char *src_prefix = getenv("CGDB_SRC_PREFIX");
         for (i = 0; i < sbcount(source_files); i++) {
-            if_add_filedlg_choice(source_files[i]);
+            if (starts_with(src_prefix, source_files[i])) {
+                if_add_filedlg_choice(source_files[i]);
+            }
         }
 
         if_set_focus(FILE_DLG);


### PR DESCRIPTION
Problem:  Hard to find files of own project: file dialog list is often bloated with files from other projects.
Solution:  File dialog only populates files with path starting with a string defined in CGDB_SRC_PREFIX environment variable.
Example: 
 $ cgdb main  => Shows lots of files in dialog
 $ CGDB_SRC_PREFIX=$PWD cgdb main  => Shows only files in current directory tree in dialog