### PR TITLE
fix memory leak in tdb_get_gdb_command

### DIFF
--- a/lib/tgdb/tgdb.cpp
+++ b/lib/tgdb/tgdb.cpp
@@ -964,15 +964,20 @@ int tgdb_get_gdb_command(struct tgdb *tgdb, tgdb_request_ptr request,
                     " \"-data-disassemble -s 0 -e 0 -- 4\"\n";
             break;
         case TGDB_REQUEST_DEBUGGER_COMMAND:
+            // tgdb_get_client_command always returns a string
+            // with static storage duration
             command = tgdb_get_client_command(tgdb,
                     request->choice.debugger_command.c);
             break;
         case TGDB_REQUEST_MODIFY_BREAKPOINT:
-            command = tgdb_client_modify_breakpoint_call(tgdb,
+            str = tgdb_client_modify_breakpoint_call(tgdb,
                     request->choice.modify_breakpoint.file,
                     request->choice.modify_breakpoint.line,
                     request->choice.modify_breakpoint.addr,
                     request->choice.modify_breakpoint.b);
+            command = str;
+            free(str);
+            str = NULL;
             break;
         case TGDB_REQUEST_COMPLETE:
             str = sys_aprintf("server interpreter-exec mi"


### PR DESCRIPTION
I run the latest version of `cgdb` with ASAN enabled. It caught a minor leak.

I think the underlying problem is that `tgdb_get_client_command` only returns literal strings, but `tgdb_client_modify_breakpoint_call` in the adjacent case returns a dynamically allocated string.

Here's the backtrace, it's not that useful since it isn't symbolicated. Not sure why.

```
==28971==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 120 byte(s) in 6 object(s) allocated from:
    #0 0x4bf0d8  (/usr/local/bin/cgdb+0x4bf0d8)
    #1 0x5ee1b4  (/usr/local/bin/cgdb+0x5ee1b4)
    #2 0x5eedc3  (/usr/local/bin/cgdb+0x5eedc3)
    #3 0x54870f  (/usr/local/bin/cgdb+0x54870f)
    #4 0x545443  (/usr/local/bin/cgdb+0x545443)
    #5 0x542947  (/usr/local/bin/cgdb+0x542947)
    #6 0x51c7e9  (/usr/local/bin/cgdb+0x51c7e9)
    #7 0x519b84  (/usr/local/bin/cgdb+0x519b84)
    #8 0x51ad0a  (/usr/local/bin/cgdb+0x51ad0a)
    #9 0x4f9e13  (/usr/local/bin/cgdb+0x4f9e13)
    #10 0x4f9aff  (/usr/local/bin/cgdb+0x4f9aff)
    #11 0x4f5f0f  (/usr/local/bin/cgdb+0x4f5f0f)
    #12 0x4f4e9a  (/usr/local/bin/cgdb+0x4f4e9a)
    #13 0x7fd17906282f  (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
```

Here are the lines in master that the frames corresponds to

```
line 44 sys_util.cpp
line 208 sys_util.cpp
Line 971 of "tgdb.cpp"
line 512 of tgdb.cpp
Line 478 of "tgdb.cpp"
Line 1232 of "interface.cpp"
Line 1508 of "interface.cpp"
Line 1542 of "interface.cpp"
Line 935 of "cgdb.cpp" 
Line 1440 of "cgdb.cpp" 
Line 1854 of "cgdb.cpp"
```

If it's acceptable, how do I sign off on this patch?