### PR TITLE
Replace NULL with nullptr to fix "no viable overloaded '='"

### DIFF
--- a/lib/kui/kui_tree.cpp
+++ b/lib/kui/kui_tree.cpp
@@ -184,7 +184,7 @@ int kui_tree_reset_state(struct kui_tree *ktree)
     ktree->cur = ktree->root;
     ktree->state = KUI_TREE_MATCHING;
     ktree->found = 0;
-    ktree->found_node = NULL;
+    ktree->found_node = nullptr;
 
     return 0;
 }
@@ -236,7 +236,7 @@ int kui_tree_push_key(struct kui_tree *ktree, int key, int *map_found)
     /* Not found */
     if (iter == ktree->cur->children.end()) {
         ktree->state = KUI_TREE_NOT_FOUND;
-        ktree->cur = NULL;
+        ktree->cur = nullptr;
     } else {
         ktree->cur = iter->second;
 


### PR DESCRIPTION
These errors happen with clang on macOS:

 kui_tree.cpp:187:23: error: no viable overloaded '='
     ktree->found_node = NULL;
     ~~~~~~~~~~~~~~~~~ ^ ~~~~
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:3740:17: note: candidate fu
 nction not viable: no known conversion from 'long' to 'const std::__1::shared_ptr<kui_tree_node>' for 1st argument
     shared_ptr& operator=(const shared_ptr& __r) _NOEXCEPT;
                 ^
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:3748:9: note: candidate tem
 plate ignored: could not match 'shared_ptr<type-parameter-0-0>' against 'long'
         operator=(const shared_ptr<_Yp>& __r) _NOEXCEPT;
         ^
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:3781:9: note: candidate tem
 plate ignored: could not match 'auto_ptr<type-parameter-0-0>' against 'long'
         operator=(auto_ptr<_Yp> __r);
         ^
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:3796:9: note: candidate tem
 plate ignored: could not match 'unique_ptr<type-parameter-0-0, type-parameter-0-1>' against 'long'
         operator=(unique_ptr<_Yp, _Dp> __r);
         ^
 kui_tree.cpp:239:20: error: no viable overloaded '='
         ktree->cur = NULL;
         ~~~~~~~~~~ ^ ~~~~
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:3740:17: note: candidate fu
 nction not viable: no known conversion from 'long' to 'const std::__1::shared_ptr<kui_tree_node>' for 1st argument
     shared_ptr& operator=(const shared_ptr& __r) _NOEXCEPT;
                 ^
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:3748:9: note: candidate tem
 plate ignored: could not match 'shared_ptr<type-parameter-0-0>' against 'long'
         operator=(const shared_ptr<_Yp>& __r) _NOEXCEPT;
         ^
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:3781:9: note: candidate tem
 plate ignored: could not match 'auto_ptr<type-parameter-0-0>' against 'long'
         operator=(auto_ptr<_Yp> __r);
         ^
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:3796:9: note: candidate tem
 plate ignored: could not match 'unique_ptr<type-parameter-0-0, type-parameter-0-1>' against 'long'
         operator=(unique_ptr<_Yp, _Dp> __r);
         ^
 2 errors generated.