### PR TITLE
build: Fix a build error by adding -std=c++11

### DIFF
--- a/cgdb/Makefile.am
+++ b/cgdb/Makefile.am
@@ -5,7 +5,8 @@ AM_CXXFLAGS = \
     -I$(top_srcdir)/lib/rline \
     -I$(top_srcdir)/lib/util \
     -I$(top_srcdir)/lib/tgdb \
-    -I$(top_srcdir)/lib/tokenizer
+    -I$(top_srcdir)/lib/tokenizer \
+    -std=c++11
 
 bin_PROGRAMS = cgdb
 

--- a/lib/kui/Makefile.am
+++ b/lib/kui/Makefile.am
@@ -1,5 +1,6 @@
 AM_CXXFLAGS = \
-    -I$(top_srcdir)/lib/util
+    -I$(top_srcdir)/lib/util \
+    -std=c++11
 
 # create the input library
 noinst_LIBRARIES = libkui.a

--- a/lib/rline/Makefile.am
+++ b/lib/rline/Makefile.am
@@ -1,5 +1,6 @@
 AM_CXXFLAGS = \
-    -I$(top_srcdir)/lib/util
+    -I$(top_srcdir)/lib/util \
+    -std=c++11
 
 noinst_LIBRARIES = librline.a
 librline_a_SOURCES = \

--- a/lib/tgdb/Makefile.am
+++ b/lib/tgdb/Makefile.am
@@ -1,7 +1,8 @@
 AM_CXXFLAGS = \
     -I$(top_srcdir)/lib/rline \
     -I$(top_srcdir)/lib/util \
-    -I$(top_srcdir)/lib/tgdb
+    -I$(top_srcdir)/lib/tgdb \
+    -std=c++11
 
 noinst_LIBRARIES = libtgdb.a
 

--- a/lib/tokenizer/Makefile.am
+++ b/lib/tokenizer/Makefile.am
@@ -1,5 +1,6 @@
 AM_CXXFLAGS = \
-    -I$(top_srcdir)/lib/util
+    -I$(top_srcdir)/lib/util \
+    -std=c++11
 
 #AM_LFLAGS = -Pxx -olex.yy.c
 


### PR DESCRIPTION
Since cgdb uses some C++11 syntax, it'd be better to set the C++
standard explicitly.

This patch is to fix the below compilation error.
```
  make[3]: Entering directory '/home/honggyu/src/cgdb/lib/kui'
  g++ -DHAVE_CONFIG_H -I. -I../..    -I../../lib/util -g -O2 -MT kui.o -MD -MP -MF .deps/kui.Tpo -c -o kui.o kui.cpp
  kui.cpp: In function ‘int kui_ms_destroy(kui_map_set*)’:
  kui.cpp:310:15: error: ‘it’ does not name a type
       for (auto it = kui_ms->maps.cbegin(); it != kui_ms->maps.cend();)
                 ^
  kui.cpp:310:43: error: expected ‘;’ before ‘it’
       for (auto it = kui_ms->maps.cbegin(); it != kui_ms->maps.cend();)
                                             ^
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>