### PR TITLE
build: Add explict include to avoid build error

### DIFF
--- a/lib/util/pseudo.cpp
+++ b/lib/util/pseudo.cpp
@@ -39,6 +39,7 @@
 #include <fcntl.h>
 #include <grp.h>
 #include <pwd.h>
+#include <utmp.h>
 
 /* With out this, cgdb will crash on gentoo when built with a 64 bit machine */
 #ifdef HAVE_STDINT_H


### PR DESCRIPTION
This patch is to avoid the following compilation error.
```
  cgdb/lib/util/pseudo.cpp:203: error: undefined reference to 'openpty'
```
Since 'openpty' requires 'utmp.h', it'd be better to include it
explicitly.  This error was found when trying cross compilation.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>