### PR TITLE
Fix for #211: newer GDB garbles output

### DIFF
--- a/lib/util/fork_util.cpp
+++ b/lib/util/fork_util.cpp
@@ -126,7 +126,7 @@ int pty_free_process(int *masterfd, char *sname)
     return 0;
 }
 
-/** 
+/**
  * Utility function that frees up memory.
  *
  * \param argc
@@ -189,8 +189,10 @@ int invoke_debugger(const char *path,
     const char *const GDBMI = "-i=mi2";
     const char *const SET_ANNOTATE_TWO = "set annotate 2";
     const char *const SET_HEIGHT_ZERO = "set height 0";
+    const char *const SET_PAGINATION_DISABLED = "set pagination off";
+
     char **local_argv;
-    int i, j = 0, extra = 8;
+    int i, j = 0, extra = 10;
     int malloc_size = argc + extra;
     char slavename[64];
     int masterfd;
@@ -204,7 +206,7 @@ int invoke_debugger(const char *path,
         local_argv[j++] = cgdb_strdup(GDB);
 
     /* NOTE: These options have to come first, since if the user
-     * typed '--args' to GDB, everything at the end of the 
+     * typed '--args' to GDB, everything at the end of the
      * users options become parameters to the inferior.
      */
     local_argv[j++] = cgdb_strdup(NW);
@@ -214,6 +216,9 @@ int invoke_debugger(const char *path,
 
     local_argv[j++] = cgdb_strdup(EX);
     local_argv[j++] = cgdb_strdup(SET_HEIGHT_ZERO);
+
+    local_argv[j++] = cgdb_strdup(EX);
+    local_argv[j++] = cgdb_strdup(SET_PAGINATION_DISABLED);
 
     /* add the init file that the user did not type */
     if (choice == 0)
@@ -257,8 +262,8 @@ int invoke_debugger(const char *path,
 
         execvp(local_argv[0], local_argv);
 
-        /* Will get here if exec failed. This will happen when the 
-         * - "gdb" is not on the users path, or if 
+        /* Will get here if exec failed. This will happen when the
+         * - "gdb" is not on the users path, or if
          * - user specified a different program via the -d option and it was
          *   not able to be exec'd.
          */


### PR DESCRIPTION
This patch fixes issue #211. I just ran into it when I updated to gdb  8.3 

GDB 8.3 (maybe older ones too, but I just noticed it),
has a problem with the code that produces annotations.

Inside gdb, the following code produces prompt annotation:

handle_line_of_input
  if (from_tty && annotation_level > 1)
    {
      printf_unfiltered (("\n\032\032post-"));
      puts_unfiltered (annotation_suffix);
      printf_unfiltered (("\n"));
    }

If gdb is launched without "set pagination off", the code
above produces out of order output which looks like this:

\r\nprompt\032\032post-\r\n

instead of

032\032post-prompt\r\n

this causes cgdb's parser to barf, and garbled text to appear
on cgdb's terminal:

(gdb)

prompt^Z^Zpost-
(gdb)

The fix is to launch gdb with "set pagination off" flag.

This patch implements this.