### PR TITLE
make cgdb reproducible

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,7 +6,7 @@ rm -rf autom4te.cache/
 
 echo "-- Update configure.in to reflect the new version number"
 if [ "$1" = "" ]; then
-  CGDB_VERSION="${CGDB_VERSION:=`date +%Y%m%d`}"
+  CGDB_VERSION="${CGDB_VERSION:=`date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y%m%d`}"
   cp configure.init configure.ac
   perl -pi -e "s/AC_INIT\(cgdb, (.*)\)/AC_INIT\(cgdb, $CGDB_VERSION\)/g" configure.ac
 fi


### PR DESCRIPTION
By default cgdb embeds the build date which makes it impossible to
reproduce cgdb. Use SOURCE_DATE_EPOCH when available to make cgdb
reproducible

Motivation: https://reproducible-builds.org