### PR TITLE
Ncursesw should link with tinfow.

### DIFF
--- a/config/readline_check_version.m4
+++ b/config/readline_check_version.m4
@@ -7,10 +7,23 @@ AC_MSG_CHECKING(which library has the termcap functions)
 _bash_needmsg=
 fi
 AC_CACHE_VAL(bash_cv_termcap_lib,
-[AC_CHECK_LIB(]$curses_lib_name[, tgetent, bash_cv_termcap_lib=lib]$curses_lib_name[,
-  [AC_CHECK_LIB(tinfo, tgetent, bash_cv_termcap_lib=libtinfo,
-    [AC_CHECK_FUNC(tgetent, bash_cv_termcap_lib=libc,
-      bash_cv_termcap_lib=gnutermcap)])])])
+[AC_CHECK_FUNC(tgetent, bash_cv_termcap_lib=libc,
+if test "$curses_lib_name" = "ncursesw"; then
+	[AC_CHECK_LIB(ncursesw, tgetent, bash_cv_termcap_lib=libncursesw,
+		[AC_CHECK_LIB(tinfow, tgetent, bash_cv_termcap_lib=libtinfow)]
+	)]
+elif test "$curses_lib_name" = "ncurses"; then
+	[AC_CHECK_LIB(ncurses, tgetent, bash_cv_termcap_lib=libncurses,
+		[AC_CHECK_LIB(tinfo, tgetent, bash_cv_termcap_lib=libtinfo)]
+	)]
+elif test "$curses_lib_name" = "curses"; then
+	[AC_CHECK_LIB(curses, tgetent, bash_cv_termcap_lib=libcurses)]
+else
+	[AC_CHECK_LIB(termcap, tgetent, bash_cv_termcap_lib=libtermcap,
+		bash_cv_termcap_lib=gnutermcap
+	)]
+fi
+)])
 if test "X$_bash_needmsg" = "Xyes"; then
 AC_MSG_CHECKING(which library has the termcap functions)
 fi
@@ -19,6 +32,9 @@ if test $bash_cv_termcap_lib = gnutermcap && test -z "$prefer_curses"; then
 LDFLAGS="$LDFLAGS -L./lib/termcap"
 TERMCAP_LIB="./lib/termcap/libtermcap.a"
 TERMCAP_DEP="./lib/termcap/libtermcap.a"
+elif test $bash_cv_termcap_lib = libtinfow; then
+TERMCAP_LIB=-ltinfow
+TERMCAP_DEP=
 elif test $bash_cv_termcap_lib = libtinfo; then
 TERMCAP_LIB=-ltinfo
 TERMCAP_DEP=


### PR DESCRIPTION
This patch is a response to issue #219. Ncursesw was linking with tinfo when it should have been linking with tinfow.

This issue is not unique to cgdb. I've included a brief list of reference issues and patches below:

[02/03/2017] - A similar problem occurred in the tig repository ([issue 568](https://github.com/jonas/tig/issues/568)).
[04/11/2017] - The issue was in tig by using `tinfow` with `ncursesw` ([pull request 685](https://github.com/jonas/tig/pull/585)).
[03/26/2018] - The seeming exact problem we are seeing surfaced as a Gentoo bug ([bug 651552](https://bugs.gentoo.org/651552)). 
[03/31/2018] - The Gentoo solution for mutt matched the change set for tig ([attachment 526196](https://bugs.gentoo.org/attachment.cgi?id=526196&action=diff)).
[10/21/2018] - We see a similar patch for gdb on Gentoo. ([commit 63d9497](https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=63d949769e25176de0d879cbef2b7cd80348ad0f)).

Symptoms and solution are pretty straight forward. @jgehrig sorry for the delay. Can you please test this on your Gentoo machine and report back. Additionally, if it is successful, can you include the updated `ldd` output in a comment on this PR.
