### PR TITLE
Allows for configurable ~/.cgdb location. 

### DIFF
--- a/cgdb/cgdb.cpp
+++ b/cgdb/cgdb.cpp
@@ -804,18 +804,24 @@ static void parse_long_options(int *argc, char ***argv)
  */
 static int init_home_dir(void)
 {
-    /* Get the home directory */
-    char *home_dir = getenv("HOME");
+    /* Check for a nonstandard cgdb dir location */
+    char *cgdb_home_envvar = getenv("CGDB_HOME"); 
 
-    /* Make sure the toplevel .cgdb dir exists */
-    snprintf(cgdb_home_dir, FSUTIL_PATH_MAX, "%s/.cgdb", home_dir);
+    /* Set the cgdb home directory */
+    if (cgdb_home_envvar != NULL) { 
+        snprintf(cgdb_home_dir, FSUTIL_PATH_MAX, cgdb_home_envvar); 
+    } else { 
+        snprintf(cgdb_home_dir, FSUTIL_PATH_MAX, "%s/.cgdb", getenv("HOME"));
+    }
+
+    /* Make sure the toplevel cgdb dir exists */
     if (!fs_util_create_dir(cgdb_home_dir)) {
         printf("Could not create dir %s", cgdb_home_dir);
         return -1;
     }
 
-    /* Try to create full .cgdb/logs directory */
-    snprintf(cgdb_log_dir, FSUTIL_PATH_MAX, "%s/.cgdb/logs", home_dir);
+    /* Try to create log directory */
+    snprintf(cgdb_log_dir, FSUTIL_PATH_MAX, "%s/logs", cgdb_home_dir);
     if (!fs_util_create_dir(cgdb_log_dir)) {
         printf("Could not create dir %s", cgdb_log_dir);
         return -1;

--- a/cgdb/cgdb.cpp
+++ b/cgdb/cgdb.cpp
@@ -809,7 +809,7 @@ static int init_home_dir(void)
     fs_util_disable_logging();  
 
     /* Check for a nonstandard cgdb dir location */
-    char *cgdb_home_envvar = getenv("CGDB_HOME"); 
+    char *cgdb_home_envvar = getenv("CGDB_DIR"); 
 
     /* Set the cgdb home directory */
     if (cgdb_home_envvar != NULL) { 

--- a/doc/cgdb.texi
+++ b/doc/cgdb.texi
@@ -595,11 +595,19 @@ Select the current file.
 @chapter CGDB configuration commands
 @cindex configuring CGDB
 
+By default, CGDB stores its user-specific files (such as command history,
+program logs, and config files) in the @file{~/.cgdb/} directory.  This
+location is configurable; if the environment variable @env{CGDB_DIR} is set
+to a directory name, CGDB will use the specified directory instead of
+@file{~/.cgdb/}. 
+
 There may be several features that you find useful in CGDB.  CGDB is capable
 of automating any of these commands through the use of the config file called
-@file{cgdbrc}.  It looks in @env{$HOME}@file{/.cgdb/} for that file.  If it 
-exists, CGDB executes each line in the file in order.  It is as if the user 
-typed in all the commands into the status bar after the tui was initialized.
+@file{cgdbrc}.  It looks in @env{$CGDB_DIR} for that file, or in
+@env{HOME}@file{/.cgdb/} if the @env{CGDB_DIR} environment variable is not
+set.  If the @file{cgdbrc} file exists, CGDB executes each one of its lines
+in order.  It is as if the user typed in all the commands into the status bar
+after the tui was initialized.
 
 The following variables change the behavior of some aspect of CGDB.  Many
 of these commands may be abbreviated in some way, and all boolean commands

--- a/lib/util/fs_util.cpp
+++ b/lib/util/fs_util.cpp
@@ -77,10 +77,19 @@ int fs_util_create_dir(const char *dir)
     /* Check to see if already exists, if does not exist continue */
     if (!stat(actual_dir, &st)) {
         /* The file exists, see if it is a directory */
-        if (S_ISDIR(st.st_mode))
-            return 1;
-        else {
-            clog_error(CLOG_CGDB, "file %s is not a directory", actual_dir);
+        if (S_ISDIR(st.st_mode)) {
+            /* The directory exists, see if it's readable and writable */
+            if (!faccessat(AT_FDCWD, actual_dir, R_OK | W_OK, AT_EACCESS)) {
+                return 1;
+            } else {
+                clog_error(CLOG_CGDB, 
+                        "file %s cannot be written to or read from",
+                        actual_dir);
+                return 0;
+            }
+        } else {
+            clog_error(CLOG_CGDB, "file %s is not a directory",
+                     actual_dir);
             return 0;
         }
     } else {

--- a/lib/util/fs_util.h
+++ b/lib/util/fs_util.h
@@ -13,9 +13,32 @@
  * Anyways, I think in the long run the static buffer will not be the best
  * option and it should be replaced with a dynamic data structure. However,
  * for the sake of time, it is done this way.
+ *
+ * Functions may log their output using clog; this behavior should change
+ * depending on the most recent call to 'fs_util_enable_logging' or
+ * 'fs_util_disable_logging'. Keep this in mind when adding new functions in
+ * this unit. 
  ******************************************************************************/
 
 #define FSUTIL_PATH_MAX 4096
+
+/* fs_util_enable_logging:
+ * ------------------------
+ *
+ *  Enables error message logging for fs_util functions. 
+ *
+ *  Returns nothing. 
+ */
+void fs_util_enable_logging(); 
+
+/* fs_util_disable_logging:
+ * ------------------------
+ *
+ *  Disables error message logging for fs_util functions. 
+ *
+ *  Returns nothing. 
+ */
+void fs_util_disable_logging(); 
 
 /* fs_util_is_valid:
  * -----------------
@@ -24,7 +47,7 @@
  *
  *  dir - The directory to check.
  *
- *  Returns 1 on succes and 0 on failure
+ *  Returns 1 on success and 0 on failure
  */
 int fs_util_is_valid(const char *dir);
 
@@ -35,8 +58,8 @@ int fs_util_is_valid(const char *dir);
  *
  *  dir - The directory to create.
  *
- *  Returns 
- *      1 on succes or if dir already exists.
+ *  Returns
+ *      1 on success or if dir already exists.
  *      0 on failure.
  */
 int fs_util_create_dir(const char *dir);
@@ -47,12 +70,12 @@ int fs_util_create_dir(const char *dir);
  * Creates the directory dirname in directory base
  * First calls fs_util_is_valid for base before trying to create directory.
  *
- * 
+ *
  *  base    - The directory to put the new directory dirname
  *  dirname - Then name of the directory to create in directory base
  *
- *  Returns 
- *      1 on succes or if dir already exists.
+ *  Returns
+ *      1 on success or if dir already exists.
  *      0 on failure.
  */
 int fs_util_create_dir_in_base(const char *base, const char *dirname);


### PR DESCRIPTION
We now look for an alternate '~/.cgdb' directory by checking the `CGDB_DIR` environment variable.

The addition of this feature exposed some related bugs. CGDB would segfault when the ~/.cgdb file wasn't writable due to some improper assumptions made about when logging was available. The details of my individual fixes are in the commit descriptions. 

This commit updates all associated documentation, etc, fully resolving issue #212.

Apologies for the delay, and thanks for your patience :)