### PR TITLE
configure: fix error when setting LEX

### DIFF
--- a/configure.init
+++ b/configure.init
@@ -145,7 +145,7 @@ if test "$opt_with_curses_prefix" != "no"; then
 fi
 
 dnl make sure that (f)lex is available
-if test "$LEX" != "flex" -a "$LEX" != "lex"; then
+if test "$(basename $LEX)" != "flex" -a "$(basename $LEX)" != "lex"; then
 	AC_MSG_ERROR([Please install flex before installing])
 fi
 


### PR DESCRIPTION
In case LEX is set to some custom path when running `configure`, the
configuration would fail, since it requires $LEX to contain either
'flex' or 'lex'.

This change modifies the configure script to check the basename of the
value in $LEX, allowing to specify a path to the lexer in a custom
location.