### PR TITLE
bugfix: auto source reloading isn't working

### DIFF
--- a/cgdb/sources.cpp
+++ b/cgdb/sources.cpp
@@ -1390,7 +1390,7 @@ int source_reload(struct sviewer *sview, const char *path, int force)
 
     if ((auto_source_reload || force) && dirty) {
 
-        if (release_file_memory(sview->cur) == -1)
+        if (release_file_memory(cur) == -1)
             return -1;
 
         if (load_file(cur))


### PR DESCRIPTION
Signed-off-by: stream <stream009@gmail.com>

I notice that auto source reloading feature isn't working. Sources gets reloaded if I manually reload it by issuing "edit" command. Setting "autosourcereload" is on by default.

In function source_reload(), code clear file memory pointed by sview->cur and load file pointed by cur. When source view is switch to new file, sview->cur points to the file displayed BEFORE switch to the new file, so clearing this is pointless. Subsequently called load_file doesn't do anything if file memory isn't cleared.

"edit" command also go though this function, but at the moment "edit" is executed, sview->cur is already switched to new file, so sview->cur == cur and clearing and subsequent loading work properly.