### PR TITLE
Fix breakpoint display in disassembly window

### DIFF
--- a/cgdb/sources.cpp
+++ b/cgdb/sources.cpp
@@ -1351,7 +1351,8 @@ void source_set_breakpoints(struct sviewer *sview,
                     node->lflags[line - 1].breakpt = enabled ? 1 : 2;
                 }
             }
-        } else if (breakpoints[i].addr) {
+        }
+        if (breakpoints[i].addr) {
             int line = 0;
             node = source_get_asmnode(sview, breakpoints[i].addr, &line);
             if (node) {


### PR DESCRIPTION
Currently if a user sets a breakpoint from the disassembly window, the
display of the breakpoint is moved to the source window instead (if it
available). It is not shown in the disassembly window and the breakpoint
cannot be toggled. This commit displays the breakpoint in both windows instead.

Signed-off-by: Andriy Gelman <andriy.gelman@gmail.com>