### PR TITLE
Fix for stale sources bug

### DIFF
--- a/cgdb/sources.cpp
+++ b/cgdb/sources.cpp
@@ -1390,7 +1390,7 @@ int source_reload(struct sviewer *sview, const char *path, int force)
 
     if ((auto_source_reload || force) && dirty) {
 
-        if (release_file_memory(sview->cur) == -1)
+        if (release_file_memory(cur) == -1)
             return -1;
 
         if (load_file(cur))


### PR DESCRIPTION
The problem was that `sview->cur` is not guaranteed to be equal to `cur`.
When this happens, load_file does not reload the file, because file 
already has a buffer (it was not releaseed by release_file_memory).

Fixes #221