### PR TITLE
tgdb: Rename mips to pstate

### DIFF
--- a/lib/tgdb/gdbwire.c
+++ b/lib/tgdb/gdbwire.c
@@ -2560,7 +2560,7 @@ struct gdbwire_mi_parser {
     /* The GDB/MI lexer state */
     yyscan_t mils;
     /* The GDB/MI push parser state */
-    gdbwire_mi_pstate *mips;
+    gdbwire_mi_pstate *pstate;
     /* The client parser callbacks */
     struct gdbwire_mi_parser_callbacks callbacks;
 };
@@ -2591,8 +2591,8 @@ gdbwire_mi_parser_create(struct gdbwire_mi_parser_callbacks callbacks)
     }
 
     /* Create a new push parser state instance */
-    parser->mips = gdbwire_mi_pstate_new();
-    if (!parser->mips) {
+    parser->pstate = gdbwire_mi_pstate_new();
+    if (!parser->pstate) {
         gdbwire_mi_lex_destroy(parser->mils);
         gdbwire_string_destroy(parser->buffer);
         free(parser);
@@ -2601,7 +2601,7 @@ gdbwire_mi_parser_create(struct gdbwire_mi_parser_callbacks callbacks)
 
     /* Ensure that the callbacks are non null */
     if (!callbacks.gdbwire_mi_output_callback) {
-        gdbwire_mi_pstate_delete(parser->mips);
+        gdbwire_mi_pstate_delete(parser->pstate);
         gdbwire_mi_lex_destroy(parser->mils);
         gdbwire_string_destroy(parser->buffer);
         free(parser);
@@ -2629,9 +2629,9 @@ void gdbwire_mi_parser_destroy(struct gdbwire_mi_parser *parser)
         }
 
         /* Free the push parser instance */
-        if (parser->mips) {
-            gdbwire_mi_pstate_delete(parser->mips);
-            parser->mips = NULL;
+        if (parser->pstate) {
+            gdbwire_mi_pstate_delete(parser->pstate);
+            parser->pstate = NULL;
         }
 
         free(parser);
@@ -2682,7 +2682,7 @@ gdbwire_mi_parser_parse_line(struct gdbwire_mi_parser *parser,
         pattern = gdbwire_mi_lex(parser->mils);
         if (pattern == 0)
             break;
-        mi_status = gdbwire_mi_push_parse(parser->mips, pattern, NULL,
+        mi_status = gdbwire_mi_push_parse(parser->pstate, pattern, NULL,
             parser->mils, &output);
     } while (mi_status == YYPUSH_MORE);
 


### PR DESCRIPTION
As per an old fix in gdbmi_parser.c, mips is a macro on some systems.