### PR TITLE
Stop truncating the GDB output

### DIFF
--- a/cgdb/scroller.cpp
+++ b/cgdb/scroller.cpp
@@ -144,28 +144,6 @@ static char *parse(struct scroller *scr, struct hl_line_attr **attrs,
     }
 
     scr->current.pos = i;
-
-    /**
-     * The prompt should never be longer than the width of the terminal.
-     *
-     * The below should only be done for the readline prompt interaction,
-     * not for text coming from gdb/inferior. Otherwise you'll truncate
-     * their text in the scroller!
-     *
-     * When readline is working with the prompt (at least in "dumb" mode)
-     * it assumes that the terminal will only display as many characters as
-     * the terminal is wide. If the terminal is reduced in size (resized to a
-     * smaller width) readline will only clear the number of characters
-     * that will fit into the new terminal width. Our prompt may still
-     * have a lot more characters than that (the characters that existed
-     * in the prompt before the resize). This truncation of the prompt
-     * is solving that problem.
-     */
-    size_t rvlength = strlen(rv);
-    if (rvlength >= width) {
-        rv[width - 1] = 0;
-    }
-
     return rv;
 }
 


### PR DESCRIPTION
Inspired by [this StackOverflow question](https://stackoverflow.com/q/68749854).

The block of code I removed had a comment above it stating that it shall not be performed for text coming from the GDB or from the process being debugged.\
Its containing function though is only ever called [here](../blob/08ed6bc88bd85227f8986b86149d01d7e0c30499/cgdb/scroller.cpp#L323) and [here](../blob/08ed6bc88bd85227f8986b86149d01d7e0c30499/cgdb/scroller.cpp#L344) and nowhere else, since it is `static` and thus is local to its compilation unit — and in both cases it ends up processing GDB-related text.

This leads me to believe that the removed block was indeed wrong.\
With it, CGDB needlessly truncated the output of its nested GDB, whereas without it everything works as expected.