### PR TITLE
standard files must be here

### DIFF
--- a/cgdb/cgdb.cpp
+++ b/cgdb/cgdb.cpp
@@ -1,64 +1,34 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <ctype.h>
+#include <string.h>
+
+#include <string>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/select.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#if HAVE_GETOPT_H
+//this *may* only be for GNU extensions getopt_long && getopt_long_only
+#include <getopt.h>
+#endif /* HAVE_GETOPT_H */
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
-
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif /* HAVE_SYS_TYPES_H */
-
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#endif /* HAVE_FCNTL_H */
-
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-
-#if HAVE_SIGNAL_H
-#include <signal.h>
-#endif
-
-#if HAVE_STDLIB_H
-#include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_STDIO_H
-#include <stdio.h>
-#endif /* HAVE_STDIO_H */
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
 
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif /* HAVE_SYS_SELECT_H */
-
-#if HAVE_SYS_STAT_H
-#include <sys/stat.h>
-#endif
-
-#if HAVE_STRING_H
-#include <string.h>
-#endif /* HAVE_STRING_H */
-
 #if HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif /* HAVE_SYS_IOCTL_H */
-
-#if HAVE_ERRNO_H
-#include <errno.h>
-#endif /* HAVE_ERRNO_H */
-
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#endif
-
-#if HAVE_CTYPE_H
-#include <ctype.h>
-#endif
-
-#include <string>
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>

--- a/cgdb/cgdbrc.cpp
+++ b/cgdb/cgdbrc.cpp
@@ -4,17 +4,12 @@
 
 #include <list>
 
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
+#include <stdlib.h>
 
 #if HAVE_STRINGS_H
 #include <strings.h>
 #endif /* HAVE_STRINGS_H */
-
-#if HAVE_STDLIB_H
-#include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
 
 #include "cgdbrc.h"
 #include "command_lexer.h"

--- a/cgdb/cgdbrc.h
+++ b/cgdb/cgdbrc.h
@@ -5,9 +5,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
 
 /* TODO: Remove this include. It is simply used to get 
  * enum tokenizer_language_support.

--- a/cgdb/filedlg.cpp
+++ b/cgdb/filedlg.cpp
@@ -2,13 +2,8 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 
 #include <string>
 

--- a/cgdb/highlight.cpp
+++ b/cgdb/highlight.cpp
@@ -8,13 +8,9 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 
-#if HAVE_REGEX_H
 #include <regex.h>
-#endif /* HAVE_REGEX_H */
 
 /* Local Includes */
 #include "sys_util.h"

--- a/cgdb/highlight_groups.cpp
+++ b/cgdb/highlight_groups.cpp
@@ -3,17 +3,9 @@
 #endif /* HAVE_CONFIG_H */
 
 /* System Includes */
-#if HAVE_CTYPE_H
 #include <ctype.h>
-#endif
-
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 
 #include "sys_util.h"
 #include "stretchy.h"

--- a/cgdb/interface.cpp
+++ b/cgdb/interface.cpp
@@ -35,39 +35,21 @@
 #endif /* HAVE_CONFIG_H */
 
 /* System Includes */
-#if HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
-#if HAVE_STDARG_H
 #include <stdarg.h>
-#endif /* HAVE_STDARG_H */
 
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
+#include <ctype.h>
+#include <assert.h>
 
 #if HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif /* HAVE_SYS_IOCTL_H */
 
-#if HAVE_UNISTD_H
 #include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-
-#if HAVE_TERMIOS_H
 #include <termios.h>
-#endif /* HAVE_TERMIOS_H */
-
-#if HAVE_CTYPE_H
-#include <ctype.h>
-#endif
-
-#include <assert.h>
 
 #include <string>
 

--- a/cgdb/logo.cpp
+++ b/cgdb/logo.cpp
@@ -11,17 +11,9 @@
 #endif /* HAVE_CONFIG_H */
 
 /* System Includes */
-#if HAVE_STDLIB_H 
 #include <stdlib.h>
-#endif  /* HAVE_STDLIB_H */
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
-
-#if HAVE_TIME_H
 #include <time.h>
-#endif /* HAVE_TIME_H */
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>

--- a/cgdb/scroller.cpp
+++ b/cgdb/scroller.cpp
@@ -55,17 +55,9 @@
 #endif /* HAVE_CONFIG_H */
 
 /* System Includes */
-#if HAVE_CTYPE_H
 #include <ctype.h>
-#endif
-
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 
 #include <algorithm>
 

--- a/cgdb/sources.cpp
+++ b/cgdb/sources.cpp
@@ -16,37 +16,18 @@
 #endif /* HAVE_CONFIG_H */
 
 /* System Includes */
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
+#include <ctype.h>
+#include <stdint.h>
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
 
-#if HAVE_SYS_STAT_H
-#include <sys/stat.h>
-#endif
-
-#if HAVE_UNISTD_H
 #include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-
-#if HAVE_CTYPE_H
-#include <ctype.h>
-#endif
-
-#ifdef HAVE_STDINT_H
-#include <stdint.h>
-#endif
+#include <sys/stat.h>
 
 /* Local Includes */
 #include "sys_util.h"

--- a/cgdb/usage.cpp
+++ b/cgdb/usage.cpp
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
 
 #include "usage.h"
 
@@ -14,12 +12,9 @@ void usage(void)
             "   cgdb [cgdb options] [--] [gdb options]\n" "\n" "CGDB Options:\n"
 #ifdef HAVE_GETOPT_H
             "   --version   Print version information and then exit.\n"
-#else
-            "   -v          Print version information and then exit.\n"
-#endif
-#ifdef HAVE_GETOPT_H
             "   --help      Print help (this message) and then exit.\n"
 #else
+            "   -v          Print version information and then exit.\n"
             "   -h          Print help (this message) and then exit.\n"
 #endif
             "   -d          Set debugger to use.\n"

--- a/lib/kui/kui.cpp
+++ b/lib/kui/kui.cpp
@@ -51,20 +51,12 @@
 #include "config.h"
 #endif
 
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif
-
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif
-
-#include <fcntl.h>
 #include <errno.h>
+
+#include <unistd.h>
+#include <fcntl.h>
 
 #include <map>
 #include <list>

--- a/lib/kui/kui_driver.cpp
+++ b/lib/kui/kui_driver.cpp
@@ -2,47 +2,22 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include <regex.h>
+#include <unistd.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <sys/types.h>
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
 
 /* Library includes */
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
-
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-
-#ifdef HAVE_REGEX_H
-#include <regex.h>
-#endif
-
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
-#if HAVE_STRING_H
-#include <string.h>
-#endif /* HAVE_STRING_H */
-
-#if HAVE_ERRNO_H
-#include <errno.h>
-#endif /* HAVE_ERRNO_H */
-
-#if HAVE_STDLIB_H
-#include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-
 #ifdef HAVE_GETOPT_H
 #include <getopt.h>
 #endif
@@ -73,12 +48,9 @@ static void usage(void)
             "   kui_driver [kui options]\r\n" "\r\n" "KUI Options:\r\n"
 #ifdef HAVE_GETOPT_H
             "   --file      Load an rc file consisting of map and unmap commands.\r\n"
-#else
-            "   -f          Load an rc file consisting of map and unmap commands.\r\n"
-#endif
-#ifdef HAVE_GETOPT_H
             "   --help      Print help (this message) and then exit.\r\n"
 #else
+            "   -f          Load an rc file consisting of map and unmap commands.\r\n"
             "   -h          Print help (this message) and then exit.\r\n"
 #endif
             "\r\nType 'q' to quit and Ctrl-z to send map or unmap command.\r\n");

--- a/lib/kui/kui_term.cpp
+++ b/lib/kui/kui_term.cpp
@@ -2,21 +2,13 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
+#include <stdlib.h>
+#include <stdio.h>
 
 #if HAVE_STRINGS_H
 #include <strings.h>
 #endif /* HAVE_STRINGS_H */
-
-#if HAVE_STDLIB_H
-#include <stdlib.h>             /* for getenv */
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_STDIO_H
-#include <stdio.h>              /* for stderr */
-#endif /* HAVE_STDIO_H */
 
 /* term.h prototypes */
 #ifdef __cplusplus

--- a/lib/rline/rline.cpp
+++ b/lib/rline/rline.cpp
@@ -7,25 +7,15 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
+#include <string.h>
+
+#include <termios.h>
 
 #if HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif /* HAVE_SYS_IOCTL_H */
-
-#if HAVE_TERMIOS_H
-#include <termios.h>
-#endif /* HAVE_TERMIOS_H */
-
-#if HAVE_STRING_H
-#include <string.h>
-#endif /* HAVE_STRING_H */
 
 /* includes {{{*/
 

--- a/lib/tgdb/driver.cpp
+++ b/lib/tgdb/driver.cpp
@@ -2,46 +2,20 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
-#if HAVE_STDARG_H
+#include <stdlib.h>
 #include <stdarg.h>
-#endif /* HAVE_STDARG_H */
+#include <string.h>
+#include <errno.h>
+
+#include <unistd.h>
+#include <signal.h>
+#include <sys/select.h>
+#include <sys/types.h>
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-
-/* Library includes */
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
-
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
-#if HAVE_STRING_H
-#include <string.h>
-#endif /* HAVE_STRING_H */
-
-#if HAVE_ERRNO_H
-#include <errno.h>
-#endif /* HAVE_ERRNO_H */
-
-#if HAVE_SIGNAL_H
-#include <signal.h>
-#endif
-
-#if HAVE_STDLIB_H
-#include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
 
 /* Local includes */
 #include "tgdb.h"

--- a/lib/tgdb/tgdb.cpp
+++ b/lib/tgdb/tgdb.cpp
@@ -3,25 +3,12 @@
 #include "config.h"
 #endif
 
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-
-#if HAVE_SIGNAL_H
-#include <signal.h> /* sig_atomic_t */
-#endif
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 
-#if HAVE_SYS_WAIT_H
+#include <unistd.h>
+#include <signal.h> /* sig_atomic_t */
 #include <sys/wait.h>
-#endif
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>

--- a/lib/tgdb/tgdb.h
+++ b/lib/tgdb/tgdb.h
@@ -1,9 +1,7 @@
 #ifndef __TGDB_H__
 #define __TGDB_H__
 
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 
 /*! 
  * \file

--- a/lib/util/driver.cpp
+++ b/lib/util/driver.cpp
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
 
 /* 
    http://stackoverflow.com/questions/27159322/rgb-values-of-the-colors-in-the-ansi-extended-colors-index-17-255

--- a/lib/util/fork_util.cpp
+++ b/lib/util/fork_util.cpp
@@ -2,37 +2,14 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
-
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-
-#if HAVE_SYS_STAT_H
-#include <sys/stat.h>
-#endif
-
-#if HAVE_SIGNAL_H
-#include <signal.h>
-#endif /* HAVE_SIGNAL_H */
-
-#if HAVE_ERRNO_H
 #include <errno.h>
-#endif /* HAVE_ERRNO_H */
+
+#include <unistd.h>
+#include <signal.h>
+#include <sys/stat.h>
 
 #include "sys_util.h"
 #include "fork_util.h"

--- a/lib/util/fs_util.cpp
+++ b/lib/util/fs_util.cpp
@@ -2,33 +2,14 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
-
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-
-#if HAVE_SYS_STAT_H
-#include <sys/stat.h>
-#endif
-
-#if HAVE_SIGNAL_H
-#include <signal.h>
-#endif /* HAVE_SIGNAL_H */
-
-#if HAVE_ERRNO_H
 #include <errno.h>
-#endif /* HAVE_ERRNO_H */
+
+#include <unistd.h>
+#include <signal.h>
+#include <sys/stat.h>
 
 #include "sys_util.h"
 #include "fs_util.h"

--- a/lib/util/io.cpp
+++ b/lib/util/io.cpp
@@ -2,53 +2,22 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
-#if HAVE_STDARG_H
 #include <stdarg.h>
-#endif /* HAVE_STDARG_H */
-
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#if HAVE_ERRNO_H
 #include <errno.h>
-#endif /* HAVE_ERRNO_H */
-
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-
-#if HAVE_SYS_STAT_H
-#include <sys/stat.h>
-#endif
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 
-#ifdef HAVE_FCNTL_H
+#include <unistd.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+
 #include <fcntl.h>
-#endif /* HAVE_FCNTL_H */
-
-#if HAVE_SYS_TYPES_H
 #include <sys/types.h>
-#endif /* HAVE_SYS_TYPES_H */
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif /* HAVE_SYS_SELECT_H */
-
-#if HAVE_ERRNO_H
-#include <errno.h>
-#endif /* HAVE_ERRNO_H */
 
 #include "sys_util.h"
 #include "cgdb_clog.h"
@@ -176,7 +145,6 @@ int io_data_ready(int fd, int ms)
 {
     int ret;
 
-#if defined(HAVE_SYS_SELECT_H)
     fd_set readfds, exceptfds;
     struct timeval timeout;
     struct timeval *timeout_ptr = &timeout;
@@ -203,7 +171,6 @@ int io_data_ready(int fd, int ms)
         return 0;               /* Nothing to read. */
     else
         return 1;
-#endif
 }
 
 int io_getchar(int fd, unsigned int ms, int *key)

--- a/lib/util/pseudo.cpp
+++ b/lib/util/pseudo.cpp
@@ -41,10 +41,9 @@
 #include <pwd.h>
 
 /* With out this, cgdb will crash on gentoo when built with a 64 bit machine */
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #ifdef HAVE_PTY_H
+//not standard in POSIX
 #include <pty.h>
 #endif
 #ifdef HAVE_UTIL_H
@@ -71,9 +70,6 @@
 #undef HAVE_DEV_PTMX
 #endif
 
-#ifdef HAVE_PTY_H
-#include <pty.h>
-#endif
 #if defined(HAVE_DEV_PTMX) && defined(HAVE_SYS_STROPTS_H)
 #include <sys/stropts.h>
 #endif

--- a/lib/util/stretchy.cpp
+++ b/lib/util/stretchy.cpp
@@ -1,6 +1,4 @@
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
 
 #include "sys_util.h"
 #include "stretchy.h"

--- a/lib/util/sys_util.cpp
+++ b/lib/util/sys_util.cpp
@@ -2,29 +2,13 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
-#if HAVE_STDARG_H
 #include <stdarg.h>
-#endif /* HAVE_STDARG_H */
-
-#if HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
-
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-
-#if HAVE_CTYPE_H
 #include <ctype.h>
-#endif
-
-#if HAVE_ERRNO_H
 #include <errno.h>
-#endif /* HAVE_ERRNO_H */
+
+#include <unistd.h>
 
 #define CLOG_MAIN
 #include "sys_util.h"

--- a/lib/util/sys_util.h
+++ b/lib/util/sys_util.h
@@ -5,14 +5,8 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
-
 #include <string>
 
 #include "cgdb_clog.h"

--- a/lib/util/terminal.cpp
+++ b/lib/util/terminal.cpp
@@ -1,8 +1,6 @@
 #include "terminal.h"
 
-#if HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
-#endif /* HAVE_SYS_IOCTL_H */
 
 int tty_cbreak(int fd, struct termios *orig)
 {

--- a/lib/util/terminal.h
+++ b/lib/util/terminal.h
@@ -5,13 +5,8 @@
 #include "config.h"
 #endif                          /* HAVE_CONFIG_H */
 
-#if HAVE_TERMIOS_H
 #include <termios.h>
-#endif                          /* HAVE_TERMIOS_H */
-
-#if HAVE_UNISTD_H
 #include <unistd.h>
-#endif                          /* HAVE_UNISTD_H */
 
 /** 
  * Sets terminal to cbreak mode. Also known as noncanonical mode.


### PR DESCRIPTION
This eliminates most of the HAVE_FOO_H code around, I am almost certain more can be eliminated because the stuff they include are required for cgdb to be correct or build, but I will try to find those later.