### PR TITLE
docs: Fix a few typos

### DIFF
--- a/cgdb/cgdb.cpp
+++ b/cgdb/cgdb.cpp
@@ -126,7 +126,7 @@ struct kui_map_set *kui_imap = NULL;
  *
  * For example, when the user types 'o' at the CGDB source window, the
  * user is requesting the file dialog to open. CGDB must first ask GDB for 
- * the list of files. While it is retreiving these files, CGDB shouldn't 
+ * the list of files. While it is retrieving these files, CGDB shouldn't 
  * shoot through the rest of the kui keys available. If the user had
  * typed 'o /main' they would want to open the file dialog and start 
  * searching for a file that had the substring 'main' in it. So, CGDB must

--- a/cgdb/cgdbrc.h
+++ b/cgdb/cgdbrc.h
@@ -30,7 +30,7 @@
  * point there is only need for one cgdbrc package. Feel free to make
  * a 'struct cgdbrc' if it's needed in the future.
  *
- * Also, the higlight_group package is really part of the configuration too.
+ * Also, the highlight_group package is really part of the configuration too.
  * Feel free to integrate the two files somehow.
  */
 
@@ -223,7 +223,7 @@ int cgdbrc_get_int(enum cgdbrc_option_kind option);
 enum LineDisplayStyle cgdbrc_get_displaystyle(enum cgdbrc_option_kind option);
 
 /**
- * A convience function for determining the timeout that should be used to
+ * A convenience function for determining the timeout that should be used to
  * allow a key code sequence to complete. This function can not fail.
  *
  * \return
@@ -233,7 +233,7 @@ enum LineDisplayStyle cgdbrc_get_displaystyle(enum cgdbrc_option_kind option);
 int cgdbrc_get_key_code_timeoutlen(void);
 
 /**
- * A convience function for determining the timeout that should be used to
+ * A convenience function for determining the timeout that should be used to
  * allow a mapped key sequence to complete. This function can not fail.
  *
  * \return

--- a/cgdb/highlight_groups.h
+++ b/cgdb/highlight_groups.h
@@ -126,7 +126,7 @@ int hl_groups_shutdown(hl_groups_ptr hl_groups);
 /******************************************************************************/
 /**
  * @name Functional commands
- * These functinos are used to ask the hl_groups context to perform a task.
+ * These functions are used to ask the hl_groups context to perform a task.
  */
 /******************************************************************************/
 

--- a/cgdb/scroller.cpp
+++ b/cgdb/scroller.cpp
@@ -8,7 +8,7 @@
 //   Allows iterating from 0:height-1 but displaying the scrolled to text
 //   The default is 0, which is represented by d0
 //   Scrolling back all the way to -6 is represented by d-6
-//   Scrolling back partiall to -2 is represented by d-2
+//   Scrolling back partially to -2 is represented by d-2
 // - The scroller has introduced the concept of a search id (sid)
 //   The purpose is to iterate easily over all the text (vterm+scrollback)
 //
@@ -224,7 +224,7 @@ void scr_up(struct scroller *scr, int nlines)
     // When moving 1 line up
     //   Move the cursor towards the top of the screen
     //   If it hits the top, then start scrolling back
-    // Otherwise whem moving many lines up, simply scroll
+    // Otherwise when moving many lines up, simply scroll
     if (scr->scroll_cursor_row > 0 && nlines == 1) {
         scr->scroll_cursor_row = scr->scroll_cursor_row - 1;
     } else {
@@ -241,7 +241,7 @@ void scr_down(struct scroller *scr, int nlines)
     // When moving 1 line down
     //   Move the cursor towards the botttom of the screen
     //   If it hits the botttom, then start scrolling forward
-    // Otherwise whem moving many lines down, simply scroll
+    // Otherwise when moving many lines down, simply scroll
     if (scr->scroll_cursor_row < height - 1 && nlines == 1) {
         scr->scroll_cursor_row = scr->scroll_cursor_row + 1;
     } else {

--- a/cgdb/sources.cpp
+++ b/cgdb/sources.cpp
@@ -220,7 +220,7 @@ static char *detab_buffer(char *buffer, int tabstop)
  * name of file to load
  *
  * \return
- * 0 on sucess, -1 on error
+ * 0 on success, -1 on error
  */
 static int load_file_buf(struct buffer *buf, const char *filename)
 {


### PR DESCRIPTION
There are small typos in:
- cgdb/cgdb.cpp
- cgdb/cgdbrc.h
- cgdb/highlight_groups.h
- cgdb/scroller.cpp
- cgdb/sources.cpp

Fixes:
- Should read `when` rather than `whem`.
- Should read `convenience` rather than `convience`.
- Should read `success` rather than `sucess`.
- Should read `retrieving` rather than `retreiving`.
- Should read `partially` rather than `partiall`.
- Should read `highlight` rather than `higlight`.
- Should read `functions` rather than `functinos`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md