### PR TITLE
Make kui_tree real C++

### DIFF
--- a/lib/kui/kui.cpp
+++ b/lib/kui/kui.cpp
@@ -269,8 +269,8 @@ int kui_map_print_cgdb_key_array(struct kui_map *map)
  */
 struct kui_map_set {
     /* The ktree used in determining if a map has been reached or is being
-     * reached. Of course, nothing could match also. This structure is efficient
-     * in doing the work, it looks only at the current key read.  */
+     * reached. Of course, nothing could match also. This structure is
+     * efficient in doing the work, it looks only at the current key read.  */
     kui_tree ktree;
 
     /**
@@ -813,8 +813,8 @@ struct kui_manager {
     struct kuictx *terminal_keys;
     /* The user defined mappings */
     struct kuictx *normal_keys;
-    /* Need a reference to the terminal escape sequence mappings when destroying
-     * this context. (a list is populated in the create function)  */
+    /* Need a reference to the terminal escape sequence mappings when
+     * destroying this context. (a list is populated in the create function) */
     struct kui_map_set *terminal_key_set;
 };
 
@@ -967,8 +967,8 @@ int kui_manager_cangetkey(struct kui_manager *kuim)
      * the terminal keys processing up to the normal keys buffer after a 
      * mapping is found.
      *
-     * For now this seems to work. Essentially, the next read get's the buffered 
-     * terminal keys first which is what should happen anyways.
+     * For now this seems to work. Essentially, the next read get's the
+     * buffered terminal keys first which is what should happen anyways.
      */
     return kui_cangetkey(kuim->terminal_keys) ||
             kui_cangetkey(kuim->normal_keys);

--- a/lib/kui/kui_tree.cpp
+++ b/lib/kui/kui_tree.cpp
@@ -1,4 +1,3 @@
-#include <string>
 #include <map>
 
 #include "kui_tree.h"

--- a/lib/kui/kui_tree.cpp
+++ b/lib/kui/kui_tree.cpp
@@ -1,40 +1,22 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <memory>
-#include <map>
 #include "kui_tree.h"
 
-/* struct kui_tree_node {{{ */
+kui_tree::node::ptr_type kui_tree::node::create()
+{
+    struct expose_ctor : public node {};
+    return std::make_shared<expose_ctor>();
+}
 
-struct kui_tree_node;
-typedef std::shared_ptr<kui_tree_node> KuiTreeNodeSPtr;
-typedef std::map<int, KuiTreeNodeSPtr> KuiTreeNodeMap;
+kui_tree::kui_tree()
+    : root(node::create())
+{}
 
-/**
- * A node in a kui tree.
- */
-struct kui_tree_node {
-
-    kui_tree_node() : key(0), macro_value(NULL) {}
-
-    /* The keyboard key this node represents. */
-    int key;
-
-    /* If non-null, this node represents the macro value reached.
-     * Otherwise, this node is not the end of the macro.
-     */
-    void *macro_value;
-
-    /**
-     * The children macros from this nodes perspective.
-     */
-    KuiTreeNodeMap children;
-
-    private:
-        kui_tree_node(const kui_tree_node &other);
-        kui_tree_node &operator=(const kui_tree_node &other);
-};
+void kui_tree::insert(int *klist, kui_map *data)
+{
+    insert(root, klist, data);
+}
 
 /**
  * Inserts a map into the tree.
@@ -48,35 +30,32 @@ struct kui_tree_node {
  *
  * @param data
  * The substitution that should take place when the key mapping is reached.
- *
- * @return
- * 0 on success or -1 on error
  */
-static int kui_tree_node_insert(KuiTreeNodeSPtr node, int *klist, void *data)
+void kui_tree::insert(node::ptr_type node, int *klist, kui_map *data)
 {
-    if (!node) {
-        return -1;
-    }
-
     // If at the end of the list, done
     if (klist[0] == 0) {
         node->macro_value = data;
-        return 0;
     } else {
-        KuiTreeNodeSPtr new_node;
-        KuiTreeNodeMap::const_iterator iter = node->children.find(klist[0]);
+        node::ptr_type new_node;
+        auto iter = node->children.find(klist[0]);
 
         if (iter == node->children.end()) {
-            new_node = KuiTreeNodeSPtr(new kui_tree_node());
+            new_node = node::create();
             new_node->key = klist[0];
 
-            node->children.insert(std::make_pair(klist[0], new_node));
+            node->children.emplace(klist[0], new_node);
         } else {
             new_node = iter->second;
         }
 
-        return kui_tree_node_insert(new_node, &klist[1], data);
+        insert(new_node, &klist[1], data);
     }
+}
+
+void kui_tree::erase(int *klist)
+{
+    erase(root, klist);
 }
 
 /**
@@ -89,12 +68,10 @@ static int kui_tree_node_insert(KuiTreeNodeSPtr node, int *klist, void *data)
  * The key sequence to delete.
  * The last item in the list will have a 0 value
  */
-static int kui_tree_node_delete(KuiTreeNodeSPtr node, int *klist)
+void kui_tree::erase(node::ptr_type node, int *klist)
 {
     auto iter = node->children.find(klist[0]);
-    if (iter == node->children.end()) {
-        return -1;
-    } else {
+    if (iter != node->children.end()) {
         // Delete the requested mapping
         if (klist[1] == 0) {
             iter->second->macro_value = NULL;
@@ -111,147 +88,68 @@ static int kui_tree_node_delete(KuiTreeNodeSPtr node, int *klist)
                 node->children.erase(iter);
             }
         } else {
-            kui_tree_node_delete(iter->second, &klist[1]);
+            erase(iter->second, &klist[1]);
             if (iter->second->children.size() == 0 &&
                 iter->second->macro_value == NULL) {
                 node->children.erase(iter);
             }
         }
     }
-
-    return 0;
 }
 
-/* }}} */
-
-/* struct kui_tree {{{ */
-
-/**
- * This data structure is capable of storing a set of maps internally in such a
- * way that it is easy to see what maps are active if a char at a time is fed
- * to this structure.
- *
- * Also, it can determine what mapping was reached if one was found.
- */
-struct kui_tree {
-
-    /* The root of the tree */
-    KuiTreeNodeSPtr root;
-
-    /* The current position pointing into the tree (while looking for a map) */
-    KuiTreeNodeSPtr cur;
-
-    /* The last node found while looking for a map. */
-    /* This happens because maps can be subsets of other maps. */
-    KuiTreeNodeSPtr found_node;
-
-    /* The internal state of the tree ( still looking, map found, not found ) */
-    enum kui_tree_state state;
-    /* If a map was found at all, this is set to 1 while looking, otherwise 0. */
-    int found;
-};
-
-int kui_tree_destroy(struct kui_tree *ktree)
+kui_tree::kui_tree_state kui_tree::get_state() const
 {
-    delete ktree;
-    return 0;
+    return state;
 }
 
-struct kui_tree *kui_tree_create(void)
+void kui_tree::reset_state()
 {
-    struct kui_tree *ktree = new kui_tree();;
-    ktree->root = KuiTreeNodeSPtr(new kui_tree_node());
-
-    return ktree;
+    cur = root;
+    state = kui_tree_state::MATCHING;
+    found = 0;
+    found_node = NULL;
 }
 
-int kui_tree_insert(struct kui_tree *ktree, int *klist, void *data)
+void kui_tree::finalize_state()
 {
-    return kui_tree_node_insert(ktree->root, klist, data);
+    if (found)
+        state = kui_tree_state::FOUND;
 }
 
-int kui_tree_delete(struct kui_tree *ktree, int *klist)
+kui_map *kui_tree::get_data() const
 {
-    kui_tree_node_delete(ktree->root, klist);
-    return 0;
+    return found ? found_node->macro_value : nullptr;
 }
 
-int kui_tree_reset_state(struct kui_tree *ktree)
-{
-    if (!ktree)
-        return -1;
-
-    ktree->cur = ktree->root;
-    ktree->state = KUI_TREE_MATCHING;
-    ktree->found = 0;
-    ktree->found_node = NULL;
-
-    return 0;
-}
-
-int kui_tree_finalize_state(struct kui_tree *ktree)
-{
-    if (!ktree)
-        return -1;
-
-    if (ktree->found)
-        ktree->state = KUI_TREE_FOUND;
-
-    return 0;
-}
-
-int kui_tree_get_state(struct kui_tree *ktree, enum kui_tree_state *state)
-{
-    if (!ktree)
-        return -1;
-
-    *state = ktree->state;
-
-    return 0;
-}
-
-int kui_tree_get_data(struct kui_tree *ktree, void *data)
-{
-    if (!ktree)
-        return -1;
-
-    if (!ktree->found)
-        return -1;
-
-    memcpy(data, &ktree->found_node->macro_value, sizeof (void *));
-
-    return 0;
-}
-
-int kui_tree_push_key(struct kui_tree *ktree, int key, int *map_found)
+bool kui_tree::push_key(int key, int *map_found)
 {
     *map_found = 0;
 
-    if (ktree->state != KUI_TREE_MATCHING)
-        return -1;
+    if (state != kui_tree_state::MATCHING)
+        return false;
 
     /* Check to see if this key matches */
-    auto iter = ktree->cur->children.find(key);
+    auto iter = cur->children.find(key);
 
     /* Not found */
-    if (iter == ktree->cur->children.end()) {
-        ktree->state = KUI_TREE_NOT_FOUND;
-        ktree->cur = NULL;
+    if (iter == cur->children.end()) {
+        state = kui_tree_state::NOT_FOUND;
+        cur = NULL;
     } else {
-        ktree->cur = iter->second;
+        cur = iter->second;
 
         if (iter->second->children.size() == 0) {
-            ktree->state = KUI_TREE_FOUND;
+            state = kui_tree_state::FOUND;
         }
 
         if (iter->second->macro_value) {
-            ktree->found = 1;
-            ktree->found_node = iter->second;
+            found = 1;
+            found_node = iter->second;
             *map_found = 1;
         }
     }
 
-    return 0;
+    return true;
 }
 
 /* }}} */

--- a/lib/kui/kui_tree.h
+++ b/lib/kui/kui_tree.h
@@ -2,7 +2,6 @@
 #define __KUI_TREE_H__
 
 #include <memory>
-#include <map>
 
 /* Doxygen headers {{{ */
 /*!
@@ -18,9 +17,9 @@
  */
 /* }}} */
 
-/*@{*/
-
 struct kui_map;
+class kui_tree_node;
+using node_ptr_type = std::shared_ptr<kui_tree_node>;
 
 /* struct kui_tree {{{ */
 
@@ -157,50 +156,18 @@ public:
     /*@}*/
 
 private:
-    /**
-     * A node in a kui tree.
-     */
-    class node
-    {
-    public:
-        using ptr_type = std::shared_ptr<node>;
-
-        static ptr_type create();
-
-        /* The keyboard key this node represents. */
-        int key;
-
-        /* If non-null, this node represents the macro value reached.
-         * Otherwise, this node is not the end of the macro.
-         */
-        kui_map *macro_value;
-
-        /**
-         * The children macros from this nodes perspective.
-         */
-        std::map<int, ptr_type> children;
-
-    protected:
-        node() : key(0), macro_value(NULL) {}
-
-    private:
-        node(const node &) = delete;
-        node(node &&) = delete;
-        node &operator=(const node &) = delete;
-    };
-
-    void insert(node::ptr_type node, int *klist, kui_map *data);
-    void erase (node::ptr_type node, int *klist);
+    void insert(node_ptr_type node, int *klist, kui_map *data);
+    void erase (node_ptr_type node, int *klist);
 
     /* The root of the tree */
-    node::ptr_type root;
+    node_ptr_type root;
 
     /* The current position pointing into the tree (while looking for a map) */
-    node::ptr_type cur;
+    node_ptr_type cur;
 
     /* The last node found while looking for a map. */
     /* This happens because maps can be subsets of other maps. */
-    node::ptr_type found_node;
+    node_ptr_type found_node;
 
     /* The internal state of the tree (still looking, map found, not found) */
     kui_tree_state state;

--- a/lib/kui/kui_tree.h
+++ b/lib/kui/kui_tree.h
@@ -10,10 +10,11 @@
  * kui_tree.h
  *
  * \brief
- * This interface is the algorithm behind libkui's fast macro finding abilities.
- * It is a statefull data structure, which can be told to start matching, to
- * receive input, and then to stop matching. When it is told to stop, it knows
- * exactly which macro's have been completed, and how much data is extra.
+ * This interface is the algorithm behind libkui's fast macro finding
+ * abilities.  It is a statefull data structure, which can be told to start
+ * matching, to receive input, and then to stop matching. When it is told to
+ * stop, it knows exactly which macro's have been completed, and how much data
+ * is extra.
  */
 /* }}} */
 
@@ -35,8 +36,8 @@ class kui_tree
 public:
 
     /**
-     * Create a kui tree. This data structure is designed specifically for
-     * the Key User Interface. It should be optimized for speed, since determining
+     * Create a kui tree. This data structure is designed specifically for the
+     * Key User Interface. It should be optimized for speed, since determining
      * what key the user wants to be processed next should be fast.
      *
      * @return
@@ -49,12 +50,12 @@ public:
      */
     ~kui_tree() = default;
 
-    /******************************************************************************/
+    /*************************************************************************/
     /**
      * @name Inserting and Deleteing from a kui_tree
      * These are the basic functions of adding to and removing from a kui_tree
      */
-    /******************************************************************************/
+    /*************************************************************************/
 
     /*@{*/
 
@@ -81,13 +82,13 @@ public:
 
     /*@}*/
 
-    /******************************************************************************/
+    /*************************************************************************/
     /**
      * @name Setting and Querying the state of a kui_tree
      * A kui_tree is a stateful ADT. This interface documents how to set/get
      * the state of a particular kui tree.
      */
-    /******************************************************************************/
+    /*************************************************************************/
 
     /*@{*/
 
@@ -130,12 +131,12 @@ public:
 
     /*@}*/
 
-    /******************************************************************************/
+    /*************************************************************************/
     /**
      * @name General operations on a kui tree.
      * These function's are the basic functions used to operate on a kui tree
      */
-    /******************************************************************************/
+    /*************************************************************************/
 
     /*@{*/
 
@@ -201,10 +202,10 @@ private:
     /* This happens because maps can be subsets of other maps. */
     node::ptr_type found_node;
 
-    /* The internal state of the tree ( still looking, map found, not found ) */
+    /* The internal state of the tree (still looking, map found, not found) */
     kui_tree_state state;
 
-    /* If a map was found at all, this is set to 1 while looking, otherwise 0. */
+    /* If a map was found, this is set to 1 while looking, otherwise 0. */
     int found;
 };
 

--- a/lib/kui/kui_tree.h
+++ b/lib/kui/kui_tree.h
@@ -1,8 +1,11 @@
 #ifndef __KUI_TREE_H__
 #define __KUI_TREE_H__
 
+#include <memory>
+#include <map>
+
 /* Doxygen headers {{{ */
-/*! 
+/*!
  * \file
  * kui_tree.h
  *
@@ -14,190 +17,204 @@
  */
 /* }}} */
 
-/* struct kui_map {{{ */
-/******************************************************************************/
-/**
- * @name Creating and Destroying a kui_map.
- * These functions are for createing and destroying a kui map.
- *
- * A kui map is basically a key value pair. As far as the map is concerned both
- * the key and the value are of type 'char*'. This is because, the user needs to
- * type the map in at the keyboard. This may seem obvious at first, but things 
- * like ESCAPE and HOME have to be typed in also.
- */
-/******************************************************************************/
-
 /*@{*/
 
-struct kui_tree;
+struct kui_map;
+
+/* struct kui_tree {{{ */
 
 /**
- * Create a kui tree. This data structure is designed specifically for 
- * the Key User Interface. It should be optimized for speed, since determining
- * what key the user wants to be processed next should be fast.
+ * This data structure is capable of storing a set of maps internally in such a
+ * way that it is easy to see what maps are active if a char at a time is fed
+ * to this structure.
  *
- * @return
- * A new instance on success, or NULL on error. 
+ * Also, it can determine what mapping was reached if one was found.
  */
-struct kui_tree *kui_tree_create(void);
+class kui_tree
+{
+public:
 
-/**
- * Destroy a kui map.
- *
- * \param ktree
- * The kui tree to destroy
- *
- * @return 
- * 0 on success, or -1 on error.
- */
-int kui_tree_destroy(struct kui_tree *ktree);
+    /**
+     * Create a kui tree. This data structure is designed specifically for
+     * the Key User Interface. It should be optimized for speed, since determining
+     * what key the user wants to be processed next should be fast.
+     *
+     * @return
+     * A new instance on success, or throw std::bad_alloc on error.
+     */
+    kui_tree();
 
-/*@}*/
+    /**
+     * Destroy a kui tree.
+     */
+    ~kui_tree() = default;
 
-/******************************************************************************/
-/**
- * @name Inserting and Deleteing from a kui_tree
- * These are the basic functions of adding to and removing from a kui_tree
- */
-/******************************************************************************/
+    /******************************************************************************/
+    /**
+     * @name Inserting and Deleteing from a kui_tree
+     * These are the basic functions of adding to and removing from a kui_tree
+     */
+    /******************************************************************************/
 
-/*@{*/
+    /*@{*/
 
-/**
- * Adding a key to the kui tree.
- *
- * \param ktree
- * The tree to add a new key too.
- *
- * \param klist
- * The data to add into the tree.
- * It is a null terminated list.
- *
- * \param data
- * If this is the "value" part of the map being inserted.
- *
- * @return
- * 0 on success, or -1 on error.
- */
-int kui_tree_insert(struct kui_tree *ktree, int *klist, void *data);
+    /**
+     * Adding a key to the kui tree.
+     *
+     * \param ktree
+     * The tree to add a new key too.
+     *
+     * \param klist
+     * The data to add into the tree.
+     * It is a null terminated list.
+     *
+     * \param data
+     * If this is the "value" part of the map being inserted.
+     */
+    void insert(int *klist, kui_map *data);
 
-/**
- * Adding a key from the kui tree.
- *
- * \param ktree
- * The tree to delete a key from.
- *
- * \param klist
- * The key to remove from the tree
- * It is a null terminated list.
- *
- * @return
- * 0 on success, or -1 on error.
- */
-int kui_tree_delete(struct kui_tree *ktree, int *klist);
+    /**
+     * Removing a key from the kui tree.
+     *
+     * \param ktree
+     * The tree to delete a key from.
+     *
+     * \param klist
+     * The key to remove from the tree
+     * It is a null terminated list.
+     */
+    void erase(int *klist);
 
-/*@}*/
+    /*@}*/
 
-/******************************************************************************/
-/**
- * @name Setting and Querying the state of a kui_tree
- * A kui_tree is a stateful ADT. This interface documents how to set/get
- * the state of a particular kui tree.
- */
-/******************************************************************************/
+    /******************************************************************************/
+    /**
+     * @name Setting and Querying the state of a kui_tree
+     * A kui_tree is a stateful ADT. This interface documents how to set/get
+     * the state of a particular kui tree.
+     */
+    /******************************************************************************/
 
-/*@{*/
+    /*@{*/
 
-enum kui_tree_state {
-    KUI_TREE_FOUND = 0,
-    KUI_TREE_MATCHING,
-    KUI_TREE_NOT_FOUND,
-    KUI_TREE_ERROR
+    enum class kui_tree_state
+    {
+        FOUND = 0,
+        MATCHING,
+        NOT_FOUND,
+        ERROR
+    };
+
+    /**
+     * Get's the state of the current tree.
+     *
+     * \return
+     * The state of the tree
+     */
+    kui_tree_state get_state() const;
+
+    /**
+     * To start searching for a macro, reset the state of the tree.
+     */
+    void reset_state();
+
+    /**
+     * To finish searching for a macro, finalize the state of the tree.
+     * This allows the tree to do any book keeping it must do, and allows it
+     * to find out exaclty which macro should was called, and how many extra
+     * key strokes have been received.
+     */
+    void finalize_state();
+
+    /**
+     * Get's the data if the state is FOUND.
+     *
+     * \param ktree
+     * The tree to get the data from
+     *
+     * \return
+     * The data put in this macro on success, or nullptr on error.
+     */
+    kui_map *get_data() const;
+
+    /*@}*/
+
+    /******************************************************************************/
+    /**
+     * @name General operations on a kui tree.
+     * These function's are the basic functions used to operate on a kui tree
+     */
+    /******************************************************************************/
+
+    /*@{*/
+
+    /**
+     * Advance the state of the tree by one key.
+     *
+     * \param key
+     * The data.
+     *
+     * \param map_found
+     * returns as 1 if a map was found with this char push, otherwise 0
+     *
+     * @return
+     * true on success, or false 1 on error.
+     */
+    bool push_key(int key, int *map_found);
+
+    /*@}*/
+
+private:
+    /**
+     * A node in a kui tree.
+     */
+    class node
+    {
+    public:
+        using ptr_type = std::shared_ptr<node>;
+
+        static ptr_type create();
+
+        /* The keyboard key this node represents. */
+        int key;
+
+        /* If non-null, this node represents the macro value reached.
+         * Otherwise, this node is not the end of the macro.
+         */
+        kui_map *macro_value;
+
+        /**
+         * The children macros from this nodes perspective.
+         */
+        std::map<int, ptr_type> children;
+
+    protected:
+        node() : key(0), macro_value(NULL) {}
+
+    private:
+        node(const node &) = delete;
+        node(node &&) = delete;
+        node &operator=(const node &) = delete;
+    };
+
+    void insert(node::ptr_type node, int *klist, kui_map *data);
+    void erase (node::ptr_type node, int *klist);
+
+    /* The root of the tree */
+    node::ptr_type root;
+
+    /* The current position pointing into the tree (while looking for a map) */
+    node::ptr_type cur;
+
+    /* The last node found while looking for a map. */
+    /* This happens because maps can be subsets of other maps. */
+    node::ptr_type found_node;
+
+    /* The internal state of the tree ( still looking, map found, not found ) */
+    kui_tree_state state;
+
+    /* If a map was found at all, this is set to 1 while looking, otherwise 0. */
+    int found;
 };
-
-/**
- * To start searching for a macro, reset the state of the tree.
- *
- * \param ktree
- * The tree to start searching for a macro in.
- *
- * @return
- * 0 on success, or -1 on error.
- */
-int kui_tree_reset_state(struct kui_tree *ktree);
-
-/**
- * To finish searching for a macro, finalize the state of the tree.
- * This allows the tree to do any book keeping it must do, and allows it
- * to find out exaclty which macro should was called, and how many extra
- * key strokes have been received.
- *
- * \param ktree
- * The tree to finalize the state of.
- *
- * @return
- * 0 on success, or -1 on error.
- */
-int kui_tree_finalize_state(struct kui_tree *ktree);
-
-/**
- * Get's the state of the current tree.
- *
- * \param ktree
- * The tree to get the state of.
- *
- * \param state
- * The state of the tree
- *
- * @return
- * 0 on success, or -1 on error.
- */
-int kui_tree_get_state(struct kui_tree *ktree, enum kui_tree_state *state);
-
-/**
- * Get's the data if the state is KUI_TREE_FOUND.
- *
- * \param ktree
- * The tree to get the data from
- *
- * \param data
- * The data put in for this macro
- *
- * \return
- * 0 on success, or -1 on error.
- */
-int kui_tree_get_data(struct kui_tree *ktree, void *data);
-
-/*@}*/
-
-/******************************************************************************/
-/**
- * @name General operations on a kui tree.
- * These function's are the basic functions used to operate on a kui tree
- */
-/******************************************************************************/
-
-/*@{*/
-
-/**
- * Advance the state of the tree by one key.
- *
- * \param ktree
- * The tree to change the state of.
- *
- * \param key
- * The data.
- *
- * \param map_found
- * returns as 1 if a map was found with this char push, otherwise 0
- *
- * @return
- * 0 on success, or -1 on error.
- */
-int kui_tree_push_key(struct kui_tree *ktree, int key, int *map_found);
-
-/*@}*/
-
-/* }}} */
 
 #endif

--- a/lib/kui/kui_tree.h
+++ b/lib/kui/kui_tree.h
@@ -61,9 +61,6 @@ public:
     /**
      * Adding a key to the kui tree.
      *
-     * \param ktree
-     * The tree to add a new key too.
-     *
      * \param klist
      * The data to add into the tree.
      * It is a null terminated list.
@@ -75,9 +72,6 @@ public:
 
     /**
      * Removing a key from the kui tree.
-     *
-     * \param ktree
-     * The tree to delete a key from.
      *
      * \param klist
      * The key to remove from the tree
@@ -128,9 +122,6 @@ public:
 
     /**
      * Get's the data if the state is FOUND.
-     *
-     * \param ktree
-     * The tree to get the data from
      *
      * \return
      * The data put in this macro on success, or nullptr on error.


### PR DESCRIPTION
As a side effect, we can get rid of a few checks for nullptr, reduce the
number of allocations, we provide better encapsulation, and a clearer
API.

Signed-off-by: Pietro Cerutti <gahr@gahr.ch>