### PR TITLE
Enhance '. to jump to the executing line across files

### DIFF
--- a/cgdb/sources.cpp
+++ b/cgdb/sources.cpp
@@ -506,6 +506,7 @@ struct sviewer *source_new(SWINDOW *win)
     /* Initialize the structure */
     rv->win = win;
     rv->cur = NULL;
+    rv->cur_exe = NULL;
     rv->list_head = NULL;
 
     /* Initialize global marks */

--- a/cgdb/sources.cpp
+++ b/cgdb/sources.cpp
@@ -736,9 +736,13 @@ int source_goto_mark(struct sviewer *sview, int key)
         line = sview->jump_back_mark.line;
         node = sview->jump_back_mark.node;
     } else if (key == '.') {
-        /* Jump to currently executing line if it's set */
+        /* Jump to currently executing line in the current file, if it's set */
         line = sview->cur->exe_line;
         node = (line >= 0) ? sview->cur : NULL;
+    } else if (key == ',') {
+        /* Jump to currently executing file and line, if it's set */
+        line = sview->cur_exe ? sview->cur_exe->exe_line : -1;
+        node = (line >= 0) ? sview->cur_exe : NULL;
     }
 
     if (node) {
@@ -1193,6 +1197,11 @@ int source_set_exec_line(struct sviewer *sview, const char *path, int sel_line, 
             /* Add a new node for this file */
             sview->cur = source_add(sview, path);
         }
+    }
+
+    if (exe_line)
+    {
+        sview->cur_exe = sview->cur;
     }
 
     /* Buffer the file if it's not already */

--- a/cgdb/sources.cpp
+++ b/cgdb/sources.cpp
@@ -1199,11 +1199,6 @@ int source_set_exec_line(struct sviewer *sview, const char *path, int sel_line, 
         }
     }
 
-    if (exe_line)
-    {
-        sview->cur_exe = sview->cur;
-    }
-
     /* Buffer the file if it's not already */
     if (load_file(sview->cur))
         return 4;
@@ -1216,6 +1211,7 @@ int source_set_exec_line(struct sviewer *sview, const char *path, int sel_line, 
     if (exe_line == -1) {
         sview->cur->exe_line = -1;
     } else if (exe_line > 0) {
+        sview->cur_exe = sview->cur;
         sview->cur->exe_line = clamp_line(sview, exe_line - 1);
     }
 

--- a/cgdb/sources.cpp
+++ b/cgdb/sources.cpp
@@ -736,10 +736,6 @@ int source_goto_mark(struct sviewer *sview, int key)
         line = sview->jump_back_mark.line;
         node = sview->jump_back_mark.node;
     } else if (key == '.') {
-        /* Jump to currently executing line in the current file, if it's set */
-        line = sview->cur->exe_line;
-        node = (line >= 0) ? sview->cur : NULL;
-    } else if (key == ',') {
         /* Jump to currently executing file and line, if it's set */
         line = sview->cur_exe ? sview->cur_exe->exe_line : -1;
         node = (line >= 0) ? sview->cur_exe : NULL;

--- a/cgdb/sources.h
+++ b/cgdb/sources.h
@@ -40,6 +40,7 @@ struct sviewer_mark {
 struct sviewer {
     struct list_node *list_head;           /* File list */
     struct list_node *cur;                 /* Current node we're displaying */
+    struct list_node *cur_exe;             /* Current node we're executing */
     sviewer_mark global_marks[MARK_COUNT]; /* Global A-Z marks */
     sviewer_mark jump_back_mark;           /* Location where last jump occurred from */
 

--- a/doc/cgdb.texi
+++ b/doc/cgdb.texi
@@ -373,7 +373,10 @@ Jump to the corresponding local or global mark.
 Jump to the last jump location.
 
 @item '.
-Jump to the currently executing line.
+Jump to the currently executing line within the file.
+
+@item ',
+Jump to the currently executing line across files..
 
 @item /
 search from current cursor position.

--- a/doc/cgdb.texi
+++ b/doc/cgdb.texi
@@ -373,10 +373,7 @@ Jump to the corresponding local or global mark.
 Jump to the last jump location.
 
 @item '.
-Jump to the currently executing line within the file.
-
-@item ',
-Jump to the currently executing line across files..
+Jump to the currently executing line cross files.
 
 @item /
 search from current cursor position.

--- a/doc/cgdb.texi
+++ b/doc/cgdb.texi
@@ -373,7 +373,7 @@ Jump to the corresponding local or global mark.
 Jump to the last jump location.
 
 @item '.
-Jump to the currently executing line cross files.
+Jump to the currently executing file and line.
 
 @item /
 search from current cursor position.


### PR DESCRIPTION
The '. jump command only resolves the currently executing line in the
currently displayed buffer. When navigating source files, it's sometimes
convenient to be able to jump back to the currently executing line
across files. I've implemented ', as a variation of '. to do that.

Alternatively, if preferred, I can also implement the feature in the
original '. command.

Signed-off-by: Pietro Cerutti <gahr@gahr.ch>