### PR TITLE
Allow toggling marks with the `m` cgdb command

### DIFF
--- a/cgdb/interface.cpp
+++ b/cgdb/interface.cpp
@@ -1110,7 +1110,7 @@ toggle_breakpoint(struct sviewer *sview, enum tgdb_breakpoint_action t)
     }
 
     /* delete an existing breakpoint */
-    if (sview->cur->lflags[line].breakpt)
+    if (sview->cur->lflags[line].breakpt != line_flags::breakpt_status::none)
         t = TGDB_BREAKPOINT_DELETE;
 
     tgdb_request_modify_breakpoint(tgdb, path, line + 1, addr, t);

--- a/cgdb/sources.cpp
+++ b/cgdb/sources.cpp
@@ -672,7 +672,7 @@ static int source_get_mark_char(struct sviewer *sview,
         int i;
 
         for (i = 0; i < MARK_COUNT; i++) {
-            if (sview->global_marks[i].line == line)
+            if (sview->global_marks[i].line == line && sview->global_marks[i].node == node)
                 return 'A' + i;
         }
 

--- a/cgdb/sources.h
+++ b/cgdb/sources.h
@@ -15,6 +15,8 @@
 #define _SOURCES_H_
 
 #include "sys_win.h"
+#include <deque>
+#include <list>
 
 /* ----------- */
 /* Definitions */
@@ -83,18 +85,19 @@ struct buffer {
 };
 
 struct line_flags {
-    unsigned char breakpt : 2;
-    unsigned char has_mark : 1;
+    enum class breakpt_status{ none, enabled, disabled };
+    breakpt_status breakpt = breakpt_status::none;
+    std::list<unsigned char> marks;
 };
 
 struct list_node {
-    char *path;                 /* Full path to source file */
-    struct buffer file_buf;     /* File buffer */
-    line_flags *lflags;         /* Breakpoints */
-    int sel_line;               /* Current line selected in viewer */
-    int sel_col;                /* Current column selected in viewer */
-    int exe_line;               /* Current line executing, or -1 if not set */
-    int sel_rline;              /* Current line used by regex */
+    char *path;                    /* Full path to source file */
+    struct buffer file_buf;        /* File buffer */
+    std::deque<line_flags> lflags; /* Breakpoints */
+    int sel_line;                  /* Current line selected in viewer */
+    int sel_col;                   /* Current column selected in viewer */
+    int exe_line;                  /* Current line executing, or -1 if not set */
+    int sel_rline;                 /* Current line used by regex */
 
     enum tokenizer_language_support language;   /* The language type of this file */
 

--- a/doc/cgdb.texi
+++ b/doc/cgdb.texi
@@ -361,7 +361,7 @@ Move to the top of file.
 Move to the bottom of file or to a line number within the file.
 
 @item m[a-zA-Z]
-Set a mark at the cursor position.  A lower case letter sets a local mark
+Toggle a mark at the cursor position.  A lower case letter sets a local mark
 that is valid within one file.  An upper case letter sets a global mark
 valid between files. If there are ten files, each file can have a mark
 @samp{a}, but only one can have a mark @samp{A}.


### PR DESCRIPTION
This enhances the `m` command so that setting the same marker again at
the same location has the effect of removing the mark.

~As a side note, a location can have many marks, and the mark displayed
is the one with the lowest letter. We might want to change that so that
the most recent mark is displayed, but this requires more fundamental
changes to how marks are managed. I think I'd do that as a separate PR.~ This PR now contains functionality to display the most recently set mark.

Issue #319

Signed-off-by: Pietro Cerutti <pcerutti2@bloomberg.net>