### PR TITLE
Fix #318, add zsh completion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,3 +4,8 @@
 AUTOMAKE_OPTIONS = -Wportability foreign
 SUBDIRS=lib cgdb doc test
 DIST_SUBDIRS=lib cgdb doc test
+
+if ENABLE_ZSH_COMPLETION
+zshcompletiondir = $(ZSH_COMPLETION_DIR)
+dist_zshcompletion_DATA = data/completions/zsh/_cgdb
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -239,6 +239,19 @@ fi
 
 AH_BOTTOM([#include <cgdb_custom_config.h>])
 
+AC_ARG_WITH([zsh-completion-dir],
+    AS_HELP_STRING([--with-zsh-completion-dir[=PATH]],
+        [Install the zsh auto-completion script in this directory. @<:@default=yes@:>@]),
+    [],
+    [with_zsh_completion_dir=yes])
+if test "x$with_zsh_completion_dir" = "xyes"; then
+    ZSH_COMPLETION_DIR="$datadir/zsh/site-functions"
+else
+    ZSH_COMPLETION_DIR="$with_zsh_completion_dir"
+fi
+AC_SUBST([ZSH_COMPLETION_DIR])
+AM_CONDITIONAL([ENABLE_ZSH_COMPLETION], [test "x$with_zsh_completion_dir" != "xno"])
+
 AC_OUTPUT(
     cgdb_custom_config.h \
     Makefile \

--- a/data/completions/zsh/_cgdb
+++ b/data/completions/zsh/_cgdb
@@ -1,0 +1,12 @@
+#compdef cgdb
+
+if ((${${words[1, CURRENT]}[(I)--]})) && [[ ${words[CURRENT]} != -- ]]; then # cgdb -- <TAB>
+  _gdb
+else # cgdb <TAB> or cgdb <TAB> -- or cgdb --<TAB>
+  _arguments -s \
+    "(- : *)"{-v,--version}"[Print version information and then exit.]" \
+    "(- : *)"{-h,--help}"[Print help (this message) and then exit.]" \
+    -d"[Set debugger to use.]" \
+    -w"[Wait for debugger to attach before starting.]" \
+    --
+fi


### PR DESCRIPTION
```sh
$ ./autogen.sh
$ ./configure --prefix=/tmp/test
$ make install
$ cat /tmp/test/share/zsh/site-functions/_cgdb
#compdef cgdb

if ((${${words[1, CURRENT]}[(I)--]})); then # cgdb -- <TAB>
  _gdb
else # cgdb <TAB> or cgdb <TAB> --
  _arguments -s \
    "(- : *)"{-v,--version}"[Print version information and then exit.]" \
    "(- : *)"{-h,--help}"[Print help (this message) and then exit.]" \
    -d"[Set debugger to use.]" \
    -w"[Wait for debugger to attach before starting.]" \
    --
fi
```

You can `./configure --without-zsh-completion-dir` to disable it.