### PR TITLE
configure: Avoid implicit int in readline check

### DIFF
--- a/config/readline_check_version.m4
+++ b/config/readline_check_version.m4
@@ -86,7 +86,7 @@ AC_CACHE_VAL(ac_cv_rl_version,
 #include <stdlib.h>
 #include <readline/readline.h>
 
-main()
+int main(void)
 {
 	FILE *fp;
 	fp = fopen("conftest.rlv", "w");


### PR DESCRIPTION
Future compilers will not accept implicit ints by default, altering the outcome of the check without this change.

Related to:

  <https://fedoraproject.org/wiki/Changes/PortingToModernC>
  <https://fedoraproject.org/wiki/Toolchain/PortingToModernC>
