### PR TITLE
Allow pressing `u` in source viewer to skip to currently selected line.

### DIFF
--- a/cgdb/interface.cpp
+++ b/cgdb/interface.cpp
@@ -1128,6 +1128,37 @@ static int status_bar_input(struct sviewer *sview, int key)
     return -1;
 }
 
+static int get_sviewer_location(struct sviewer *sview, char **path, int *line,
+                                uint64_t *addr)
+{
+    char *l_path = NULL;
+    int l_line = 0;
+    uint64_t l_addr = 0;
+
+    if (!sview || !sview->cur || !sview->cur->path)
+        return -1;
+
+    l_line = sview->cur->sel_line;
+
+    if (sview->cur->path[0] == '*')
+    {
+        l_addr = sview->cur->file_buf.addrs[l_line];
+        if (!l_addr)
+            return -1;
+    }
+    else
+    {
+        l_path = sview->cur->path;
+    }
+
+    /* l_line is 0-indexed, but the actual file is 1-indexed */
+    *line = l_line + 1;
+    *path = l_path;
+    *addr = l_addr;
+
+    return 0;
+}
+
 /**
  * toggle a breakpoint
  * 
@@ -1143,31 +1174,18 @@ static int status_bar_input(struct sviewer *sview, int key)
 static int
 toggle_breakpoint(struct sviewer *sview, enum tgdb_breakpoint_action t)
 {
+    char *path;
     int line;
-    uint64_t addr = 0;
-    char *path = NULL;
+    uint64_t addr;
 
-    if (!sview || !sview->cur || !sview->cur->path)
+    if (get_sviewer_location(sview, &path, &line, &addr) == -1)
         return -1;
-
-    line = sview->cur->sel_line;
-
-    if (sview->cur->path[0] == '*')
-    {
-        addr = sview->cur->file_buf.addrs[line];
-        if (!addr)
-            return -1;
-    }
-    else
-    {
-        path = sview->cur->path;
-    }
 
     /* delete an existing breakpoint */
     if (sview->cur->lflags[line].breakpt != line_flags::breakpt_status::none)
         t = TGDB_BREAKPOINT_DELETE;
 
-    tgdb_request_modify_breakpoint(tgdb, path, line + 1, addr, t);
+    tgdb_request_modify_breakpoint(tgdb, path, line, addr, t);
     return 0;
 }
 
@@ -1262,6 +1280,15 @@ static void source_input(struct sviewer *sview, int key)
             enum tgdb_breakpoint_action t = TGDB_TBREAKPOINT_ADD;
 
             toggle_breakpoint(sview, t);
+        }
+            break;
+        case 'u':
+        {
+            char *path;
+            int line;
+            uint64_t addr;
+            if (get_sviewer_location(sview, &path, &line, &addr) != -1)
+                tgdb_request_until_line(tgdb, path, line, addr);
         }
             break;
         default:

--- a/doc/cgdb.texi
+++ b/doc/cgdb.texi
@@ -396,6 +396,9 @@ Sets a breakpoint at the current line number.
 @item t
 Sets a temporary breakpoint at the current line number.
 
+@item u
+Tells GDB to skip execution until the current line number.
+
 @item -
 Shrink source window 1 line or column (depending on split orientation).
 

--- a/lib/tgdb/tgdb.cpp
+++ b/lib/tgdb/tgdb.cpp
@@ -153,6 +153,15 @@ struct tgdb_request {
             int source;
             int raw;
         } disassemble_func;
+
+        struct {
+            // The filename to set the breakpoint in
+            const char *file;
+            // The corresponding line number
+            int line;
+            // The address to set breakpoint in (if file is null)
+            uint64_t addr;
+        } until_line;
     } choice;
 };
 
@@ -561,6 +570,7 @@ static void gdbwire_result_record_callback(void *context,
         case TGDB_REQUEST_TTY:
         case TGDB_REQUEST_DEBUGGER_COMMAND:
         case TGDB_REQUEST_MODIFY_BREAKPOINT:
+        case TGDB_REQUEST_UNTIL_LINE:
             break;
     }
 }
@@ -719,6 +729,10 @@ static void tgdb_request_destroy(tgdb_request_ptr request_ptr)
             free((char *) request_ptr->choice.modify_breakpoint.file);
             request_ptr->choice.modify_breakpoint.file = NULL;
             break;
+        case TGDB_REQUEST_UNTIL_LINE:
+            free((char *) request_ptr->choice.until_line.file);
+            request_ptr->choice.until_line.file = NULL;
+            break;
         case TGDB_REQUEST_DISASSEMBLE_PC:
         case TGDB_REQUEST_DISASSEMBLE_FUNC:
             break;
@@ -858,6 +872,16 @@ static const char *tgdb_get_client_command(struct tgdb *tgdb,
     return NULL;
 }
 
+static char *tgdb_break_call(const char *action,
+    const char *file, int line, uint64_t addr)
+{
+    if (file)
+        return sys_aprintf("%s \"%s\":%d", action, file, line);
+
+    return sys_aprintf("%s *0x%" PRIx64, action, addr);
+}
+
+
 static char *tgdb_client_modify_breakpoint_call(struct tgdb *tgdb,
     const char *file, int line, uint64_t addr, enum tgdb_breakpoint_action b)
 {
@@ -877,10 +901,7 @@ static char *tgdb_client_modify_breakpoint_call(struct tgdb *tgdb,
         break;
     }
 
-    if (file)
-        return sys_aprintf("%s \"%s\":%d", action, file, line);
-
-    return sys_aprintf("%s *0x%" PRIx64, action, addr);
+    return tgdb_break_call(action, file, line, addr);
 }
 
 /*******************************************************************************
@@ -1347,6 +1368,21 @@ void tgdb_request_disassemble_func(struct tgdb *tgdb,
     tgdb_run_or_queue_request(tgdb, request_ptr, false);
 }
 
+void tgdb_request_until_line(struct tgdb *tgdb,
+        const char *file, int line, uint64_t addr)
+{
+    tgdb_request_ptr request_ptr;
+
+    request_ptr = (tgdb_request_ptr)cgdb_malloc(sizeof (struct tgdb_request));
+    request_ptr->header = TGDB_REQUEST_UNTIL_LINE;
+
+    request_ptr->choice.until_line.file = file ? cgdb_strdup(file) : NULL;
+    request_ptr->choice.until_line.line = line;
+    request_ptr->choice.until_line.addr = addr;
+
+    tgdb_run_or_queue_request(tgdb, request_ptr, false);
+}
+
 /* }}}*/
 
 /* Process {{{*/
@@ -1394,6 +1430,15 @@ int tgdb_get_gdb_command(struct tgdb *tgdb, tgdb_request_ptr request,
                     request->choice.modify_breakpoint.line,
                     request->choice.modify_breakpoint.addr,
                     request->choice.modify_breakpoint.b);
+            command = str;
+            free(str);
+            str = NULL;
+            break;
+        case TGDB_REQUEST_UNTIL_LINE:
+            str = tgdb_break_call("until",
+                request->choice.until_line.file,
+                request->choice.until_line.line,
+                request->choice.until_line.addr);
             command = str;
             free(str);
             str = NULL;

--- a/lib/tgdb/tgdb.h
+++ b/lib/tgdb/tgdb.h
@@ -159,7 +159,10 @@
         TGDB_REQUEST_DISASSEMBLE_PC,
 
         // Request GDB to disassemble a function.
-        TGDB_REQUEST_DISASSEMBLE_FUNC
+        TGDB_REQUEST_DISASSEMBLE_FUNC,
+
+        // Request GDB to skip to the given line.
+        TGDB_REQUEST_UNTIL_LINE
     };
 
     // This is the commands interface used between the front end and TGDB.
@@ -509,6 +512,25 @@
     };
     void tgdb_request_disassemble_func(struct tgdb *tgdb,
             enum disassemble_func_type type);
+
+    /**
+     * Request GDB skip 'until' the given file/line or address. Uses the same
+     * basic functionality as 'break'. Only file/line *OR* addr should be set.
+     *
+     * \param tgdb
+     * An instance of the tgdb library to operate on.
+     *
+     * \param file
+     * The file name of the line to skip to.
+     *
+     * \param line
+     * The line to skip until.
+     *
+     * \param addr
+     * The address ($pc) to skip until.
+     */
+    void tgdb_request_until_line(struct tgdb *tgdb,
+            const char *file, int line, uint64_t addr);
 
 /*@}*/
 /* }}}*/


### PR DESCRIPTION
Add support to skip to the currently selected line with `u`, similar to
`t` and `<space>` which set a breakpoint on the currently selected line.

This uses the same functionality as TGDB_REQUEST_MODIFY_BREAKPOINT, but 
instead of sending `break <file:line>` to GDB, we send `until <file:line>`.