### PR TITLE
Restore the parts of rline_initialize that were actually useful

### DIFF
--- a/cgdb/cgdb.cpp
+++ b/cgdb/cgdb.cpp
@@ -928,14 +928,6 @@ int init_signal_pipe(void)
     return result;
 }
 
-static void rlctx_send_user_command(char *line)
-{
-}
-static int tab_completion(int a, int b)
-{
-    return 0;
-}
-
 int update_kui(cgdbrc_config_option_ptr option)
 {
     kui_ctx->set_terminal_escape_sequence_timeout(
@@ -1081,6 +1073,10 @@ int main(int argc, char *argv[])
     }
 
     /* From here on, the logger is initialized */
+    if (rline_initialize() == -1) {
+        clog_error(CLOG_CGDB, "Unable to init readline");
+        cgdb_cleanup_and_exit(-1);
+    }
 
     setlocale(LC_CTYPE, "");
 

--- a/lib/rline/rline.h
+++ b/lib/rline/rline.h
@@ -12,6 +12,23 @@
 #include <string>
 #include <list>
 
+/*@{*/
+
+/**
+ * This initializes an rline library instance.
+ *
+ * The client must call this function before any other function in the
+ * rline library.
+ *
+ * @return
+ * 0 on success or -1 on error
+ */
+int rline_initialize(void);
+
+/*@}*/
+
+/*@{*/
+
 /**
  * This will get the key sequences that readline uses for a certain key.
  *
@@ -29,6 +46,5 @@
 int rline_get_keyseq(const char *named_function, std::list<std::string> &keyseq);
 
 /*@}*/
-/* }}}*/
 
 #endif /* __RL_H__ */


### PR DESCRIPTION
As well as initializing the now-removed `struct rline`, this function also initialized the readline library proper, which had unintended side effects for cgdb's use of `rl_translate_keyseq()`.


Fixes #347