### PR TITLE
Revert rline changes

### DIFF
--- a/cgdb/cgdb.cpp
+++ b/cgdb/cgdb.cpp
@@ -58,10 +58,6 @@
 #include <ctype.h>
 #endif
 
-#if HAVE_LOCALE_H
-#include <locale.h>
-#endif
-
 #include <string>
 
 #define __STDC_FORMAT_MACROS
@@ -1081,8 +1077,6 @@ int main(int argc, char *argv[])
     }
 
     /* From here on, the logger is initialized */
-
-    setlocale(LC_CTYPE, "");
 
     if (tty_cbreak(STDIN_FILENO, &term_attributes) == -1) {
         clog_error(CLOG_CGDB, "tty_cbreak error");

--- a/cgdb/cgdb.cpp
+++ b/cgdb/cgdb.cpp
@@ -169,6 +169,9 @@ int resize_pipe[2] = { -1, -1 };
  */
 int signal_pipe[2] = { -1, -1 };
 
+/* Readline interface */
+static struct rline *rline;
+
 /* Original terminal attributes */
 static struct termios term_attributes;
 
@@ -932,6 +935,12 @@ static int tab_completion(int a, int b)
     return 0;
 }
 
+int init_readline(void)
+{
+    rline = rline_initialize(rlctx_send_user_command, tab_completion, "dumb");
+    return 0;
+}
+
 int update_kui(cgdbrc_config_option_ptr option)
 {
     kui_ctx->set_terminal_escape_sequence_timeout(
@@ -947,7 +956,7 @@ int add_readline_key_sequence(const char *readline_str, enum cgdb_key key)
     int result;
     std::list<std::string> keyseq;
 
-    result = rline_get_keyseq(readline_str, keyseq);
+    result = rline_get_keyseq(rline, readline_str, keyseq);
     if (result == 0) {
          result = kui_ctx->get_terminal_keys_kui_map(key, keyseq);
     }
@@ -1077,6 +1086,10 @@ int main(int argc, char *argv[])
     }
 
     /* From here on, the logger is initialized */
+    if (init_readline() == -1) {
+        clog_error(CLOG_CGDB, "Unable to init readline");
+        cgdb_cleanup_and_exit(-1);
+    }
 
     if (tty_cbreak(STDIN_FILENO, &term_attributes) == -1) {
         clog_error(CLOG_CGDB, "tty_cbreak error");

--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,6 @@ AC_CHECK_HEADERS([regex.h],,[AC_MSG_ERROR([CGDB requires regex.h to build.])])
 AC_CHECK_HEADERS([curses.h],,[
    AC_CHECK_HEADERS([ncurses/curses.h],,[
       AC_MSG_ERROR([CGDB requires curses.h or ncurses/curses.h to build.])])])
-AC_CHECK_HEADERS([locale.h],,[AC_MSG_ERROR([CGDB requires locale.h to build.])])
 
 dnl Check for getopt.h, If this is here then getopt_long can be used.
 AC_CHECK_HEADERS([getopt.h],

--- a/lib/rline/rline.cpp
+++ b/lib/rline/rline.cpp
@@ -1,9 +1,31 @@
+#include <stretchy.h>
+#include <sys_util.h>
 #include "rline.h"
-#include "sys_util.h"
+#include "fork_util.h"
 
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
+
+#if HAVE_STDLIB_H
+#include <stdlib.h>
+#endif /* HAVE_STDLIB_H */
+
+#if HAVE_STDIO_H
+#include <stdio.h>
+#endif /* HAVE_STDIO_H */
+
+#if HAVE_SYS_IOCTL_H
+#include <sys/ioctl.h>
+#endif /* HAVE_SYS_IOCTL_H */
+
+#if HAVE_TERMIOS_H
+#include <termios.h>
+#endif /* HAVE_TERMIOS_H */
+
+#if HAVE_STRING_H
+#include <string.h>
+#endif /* HAVE_STRING_H */
 
 /* includes {{{*/
 
@@ -15,16 +37,431 @@
 #include <readline.h>
 #endif /* !defined(HAVE_READLINE_H) */
 
+#if defined(HAVE_READLINE_HISTORY_H)
+#include <readline/history.h>
+#elif defined(HAVE_HISTORY_H)
+#include <history.h>
+#endif /* defined(HAVE_READLINE_HISTORY_H) */
+
 #endif /* HAVE_LIBREADLINE */
 
 /* }}}*/
 
+/* Our array of completion strings and current index */
+static int completions_index = 0;
+static char **completions_array = NULL;
+static int completions_array_size = 0;
+
+struct rline {
+    /* The input to readline. Writing to this, writes to readline. */
+    FILE *input;
+
+    /* The output of readline. When readline writes data, it goes to this
+     * descritpor. Thus, reading from this, get's readline's output. */
+    FILE *output;
+
+    /** Master/Slave PTY used to keep readline off of stdin/stdout. */
+    pty_pair_ptr pty_pair;
+
+    /* The user defined tab completion function */
+    completion_cb *tab_completion;
+
+    /* The user defined tab completion function */
+    rl_command_func_t *rline_rl_last_func;
+
+    /* The value of rl_completion_query_items before its set to -1.
+     * It is set to -1 so that readline will not attempt to ask "y or no",
+     * since that particular functionality of readline does not work with
+     * the alternative interface. */
+    int rline_rl_completion_query_items;
+
+};
+
+static void custom_deprep_term_function()
+{
+}
+
+/* Createing and Destroying a librline context. {{{*/
+struct rline *rline_initialize(command_cb * command,
+        completion_cb * completion, const char *TERM)
+{
+    struct rline *rline = (struct rline *) malloc(sizeof (struct rline));
+    static char word_break_chars[] = " \t\n!@#$%^&*()+=|~`}{[]\"';:?/>.<,-";
+
+    if (!rline)
+        return NULL;
+
+    /* Initialize each member variable */
+    rline->input = NULL;
+    rline->output = NULL;
+
+    rline->pty_pair = pty_pair_create();
+    if (!rline->pty_pair) {
+        return NULL;
+    }
+
+    int slavefd = pty_pair_get_masterfd(rline->pty_pair);
+
+    rline->input = fdopen(slavefd, "r");
+    if (!rline->input) {
+        rline_shutdown(rline);
+        return NULL;
+    }
+
+    rline->output = fdopen(slavefd, "w");
+    if (!rline->output) {
+        rline_shutdown(rline);
+        return NULL;
+    }
+
+    rline->tab_completion = completion;
+    rline->rline_rl_last_func = NULL;
+    rline->rline_rl_completion_query_items = rl_completion_query_items;
+
+    rl_readline_name = "cgdb";
+    rl_instream = rline->input;
+    rl_outstream = rline->output;
+
+    /* Tell readline not to put the initial prompt */
+    rl_already_prompted = 1;
+
+    /* Tell readline not to catch signals */
+    rl_catch_signals = 0;
+    rl_catch_sigwinch = 0;
+
+    /* Tell readline what the prompt is if it needs to put it back */
+    rl_callback_handler_install("(gdb) ", command);
+    rl_bind_key('\t', completion);
+
+    /* Set the terminal type to dumb so the output of readline can be
+     * understood by tgdb */
+    if (rl_reset_terminal(TERM) == -1) {
+        rline_shutdown(rline);
+        return NULL;
+    }
+
+    /* For some reason, readline can not deprep the terminal.
+     * However, it doesn't matter because no other application is working on
+     * the terminal besides readline */
+    rl_deprep_term_function = custom_deprep_term_function;
+
+    /* These variables are here to make sure readline doesn't 
+     * attempt to query the user to determine if it wants more input.
+     */
+    rl_completion_query_items = -1;
+    rl_variable_bind("page-completions", "0");
+    rl_completer_word_break_characters = word_break_chars;
+    rl_completer_quote_characters = "'";
+
+    return rline;
+}
+
+static void rline_free_completions()
+{
+    /* Set and index to 0. */
+    delete [] completions_array;
+    completions_array = NULL;
+    completions_index = 0;
+    completions_array_size = 0;
+}
+
+int rline_shutdown(struct rline *rline)
+{
+    if (!rline)
+        return -1;              /* Should this be OK? */
+
+    rline_free_completions();
+
+    if (rline->input)
+        fclose(rline->input);
+
+    if (rline->output)
+        fclose(rline->output);
+
+    pty_pair_destroy(rline->pty_pair);
+
+    free(rline);
+    rline = NULL;
+
+    return 0;
+}
+
+/*@}*/
+/* }}}*/
+
+/* Reading and Writing the librline context. {{{*/
+int rline_read_history(struct rline *rline, const char *file)
+{
+    if (!rline)
+        return -1;
+
+    using_history();
+    read_history(file);
+    history_set_pos(history_length);
+
+    return 0;
+}
+
+int rline_write_history(struct rline *rline, const char *file)
+{
+    if (!rline)
+        return -1;
+
+    write_history(file);
+
+    return 0;
+}
+
+/*@}*/
+/* }}}*/
+
+/* Functional commands {{{*/
+
+int rline_set_prompt(struct rline *rline, const char *prompt)
+{
+    if (!rline)
+        return -1;
+
+    rl_set_prompt(prompt);
+
+    return 0;
+}
+
+int rline_clear(struct rline *rline)
+{
+    if (!rline)
+        return -1;
+
+    /* Clear whatever readline has in it's buffer. */
+    rl_point = 0;
+    rl_end = 0;
+    rl_mark = 0;
+    rl_delete_text(0, rl_end);
+
+    return 0;
+}
+
+int rline_add_history(struct rline *rline, const char *line)
+{
+    if (!rline)
+        return -1;
+
+    if (!line)
+        return -1;
+
+    add_history(line);
+
+    return 0;
+}
+
+int rline_get_prompt(struct rline *rline, char **prompt)
+{
+    if (!rline)
+        return -1;
+
+    if (!prompt)
+        return -1;
+
+    *prompt = rl_prompt;
+
+    return 0;
+}
+
+int rline_get_current_line(struct rline *rline, char **current_line)
+{
+    if (!rline)
+        return -1;
+
+    if (!current_line)
+        return -1;
+
+    *current_line = rl_line_buffer;
+
+    return 0;
+}
+
+int rline_rl_forced_update_display(struct rline *rline)
+{
+    if (!rline)
+        return -1;
+
+    rl_forced_update_display();
+
+    return 0;
+}
+
+int rline_rl_callback_read_char(struct rline *rline)
+{
+    if (!rline)
+        return -1;
+
+    /* Capture the last function used here.  */
+    rline->rline_rl_last_func = rl_last_func;
+
+    rl_callback_read_char();
+
+    return 0;
+}
+
+/**
+ * Return to readline a possible completion.
+ *
+ * \param text
+ * The text that is being completed. It can be a subset of the full current 
+ * line (rl_line_buffer) at the prompt.
+ *
+ * \param matches
+ * The current number of matches so far
+ *
+ * \return
+ * A possible match, or NULL if none left.
+ */
+char *rline_rl_completion_entry_function(const char *text, int matches)
+{
+    if (completions_index < completions_array_size)
+    {
+        /**
+         * 'local' is a possible completion. 'text' is the data to be completed.
+         * 'word' is the current possible match started off at the same point
+         * in local, that text is started in rl_line_buffer.
+         *
+         * In C++ if you do "b 'classname::functionam<Tab>". This will complete
+         * the line like "b 'classname::functioname'".
+         */
+        char *local = completions_array[completions_index++];
+        char *word = local + rl_point - strlen(text);
+
+        return strdup(word);
+    }
+
+    return NULL;
+}
+
+/* This is necessary because we want to make what the user has typed
+ * against a list of possibilities. For example, if the user has typed
+ * 'b ma', the completion possibilities should at least have 'b main'.
+ * The default readline word break includes a ' ', which would not
+ * result in 'b main' as the completion result.
+ */
+static char *rline_rl_cpvfunc_t(void)
+{
+    static char buf[] = "";
+    return buf;
+}
+
+int rline_rl_complete(struct rline *rline, char **completions,
+        display_callback display_cb)
+{
+    int size;
+    int key;
+    rl_command_func_t *compare_func = NULL;
+
+    if (!rline)
+        return -1;
+
+    /* Currently, if readline output's the tab completion to rl_outstream,
+     * it will fill the pty between it and CGDB and will cause CGDB to hang. */
+    if (!display_cb)
+        return -1;
+
+    size = sbcount(completions);
+    if (size == 0) {
+        rl_completion_word_break_hook = NULL;
+        rl_completion_entry_function = NULL;
+    } else {
+        completions_index = 0;
+        completions_array_size = size;
+        completions_array = new char*[size];
+
+        for (int i = 0; i < size; i++)
+            completions_array[i] = completions[i];
+
+        rl_completion_word_break_hook = rline_rl_cpvfunc_t;
+        rl_completion_entry_function = rline_rl_completion_entry_function;
+    }
+
+    rl_completion_display_matches_hook = display_cb;
+
+    /* This is probably a hack, however it works for now.
+     *
+     * Basically, rl_complete is working fine. After the call to rl_complete,
+     * rl_line_buffer contains the proper data. However, the CGDB main loop
+     * always call rline_rl_forced_update_display, which in the case of tab 
+     * completion does this, (gdb) b ma(gdb) b main
+     *
+     * Normally, this works fine because the user hits '\n', which puts the prompt
+     * on the next line. In this case, the user hit's \t.
+     *
+     * In order work around this problem, simply putting the \r should work 
+     * for now.
+     *
+     * This obviously shouldn't be done when readline is doing 
+     *    `?' means list the possible completions.
+     * style completion. Because that actuall does list all of the values on
+     * a different line. In this situation the \r goes after the completion
+     * is done, since only the current prompt is on that line.
+     */
+
+    /* Another confusing comparison. This checks to see if the last
+     * readline function and the current readline function and the 
+     * tab completion callback are all the same. This ensures that this
+     * is the second time the user hit \t in a row. Instead of simply
+     * calling rl_complete_internal, it's better to call, rl_completion_mode
+     * because this checks to see what kind of completion should be done.
+     */
+    if (rline->rline_rl_last_func == rline->tab_completion &&
+            rline->rline_rl_last_func == rl_last_func)
+        compare_func = rline->tab_completion;
+
+    key = rl_completion_mode(compare_func);
+
+    if (key == TAB)
+        fprintf(rline->output, "\r");
+
+    rl_complete_internal(key);
+
+    if (key != TAB)
+        fprintf(rline->output, "\r");
+
+    /* Free the current completion array entries */
+    rline_free_completions();
+
+    return 0;
+}
+
+int rline_resize_terminal_and_redisplay(struct rline *rline, int rows, int cols)
+{
+    struct winsize size;
+
+    if (!rline)
+        return -1;
+
+    size.ws_row = rows;
+    size.ws_col = cols;
+    size.ws_xpixel = 0;
+    size.ws_ypixel = 0;
+    ioctl(fileno(rline->input), TIOCSWINSZ, &size);
+
+    rl_resize_terminal();
+    return 0;
+}
+
+int rline_get_rl_completion_query_items(struct rline *rline)
+{
+    if (!rline)
+        return -1;
+
+    return rline->rline_rl_completion_query_items;
+}
+
 int
-rline_get_keyseq(const char *named_function, std::list<std::string> &keyseq)
+rline_get_keyseq(struct rline *rline, const char *named_function,
+        std::list<std::string> &keyseq)
 {
     rl_command_func_t *func;
     char **invoking_keyseqs = NULL;
     char **invoking_keyseqs_cur = NULL;
+    char *new_keyseq = NULL;
     int len;
 
     func = rl_named_function(named_function);
@@ -36,15 +473,17 @@ rline_get_keyseq(const char *named_function, std::list<std::string> &keyseq)
 
     while (invoking_keyseqs_cur && (*invoking_keyseqs_cur)) {
 
-        std::string new_keyseq;
-        new_keyseq.resize((2 * strlen(*invoking_keyseqs_cur)) + 1);
-        if (rl_translate_keyseq(*invoking_keyseqs_cur, &new_keyseq[0], &len)) {
+        new_keyseq =
+                (char *) cgdb_malloc((2 * strlen(*invoking_keyseqs_cur)) + 1);
+        if (rl_translate_keyseq(*invoking_keyseqs_cur, new_keyseq, &len)) {
+            free(new_keyseq);
             free(*invoking_keyseqs_cur);
             /* Can't do much about readline failing, just continue on. */
             continue;
         }
 
-        keyseq.push_back(std::move(new_keyseq));
+        keyseq.push_back(new_keyseq);
+        free(new_keyseq);
 
         free(*invoking_keyseqs_cur);
         invoking_keyseqs_cur++;

--- a/lib/rline/rline.h
+++ b/lib/rline/rline.h
@@ -3,17 +3,292 @@
 
 /*!
  * \file
- * rline.h
+ * rl.h
  *
  * \brief
- * This interface is an abstraction layer to the key bindings in the GNU readline library.
+ * This interface is the abstraction layer to the GNU readline library.
+ * Currently readline only supports 1 instance of itself per program. Until it
+ * supports multiple instance's, this library will also only support a single
+ * instance.
  */
 
 #include <string>
 #include <list>
 
+/* Creating and Destroying a librline context. {{{ */
+/******************************************************************************/
+/**
+ * @name Creating and Destroying a librline context.
+ * These functions are for createing and destroying a rline context.
+ */
+/******************************************************************************/
+
+/*@{*/
+
+/**
+ *  This struct is a reference to a librline instance.
+ */
+struct rline;
+
+/** 
+ * The signature of the callback function that rline calls when it detects 
+ * that a command has been typed by the user. */
+typedef void command_cb(char *);
+
+/** 
+ * The signature of the callback function that rline calls when it detects 
+ * that the user has requested completion on the current line. */
+typedef int completion_cb(int, int);
+
+/**
+ * This initializes an rline library instance.
+ *
+ * The client must call this function before any other function in the 
+ * rline library.
+ *
+ * \param slavefd
+ * This is the file descriptor representing the slave side of a terminal device.
+ *
+ * \param command
+ * The command callback that should be used when readline completes a command.
+ *
+ * \param completion
+ * The completion callback that should be used when readline requests completion.
+ *
+ * \param TERM
+ * Pass in the TERM that readline should think it's output should be like.
+ *
+ * @return
+ * NULL on error, a valid context on success.
+ */
+struct rline *rline_initialize(command_cb * command,
+        completion_cb * completion, const char *TERM);
+
+/**
+ * This will terminate a librline session. No functions should be called on
+ * the rline context passed into this function after this call.
+ *
+ * \param rline
+ * An instance of the rline library to operate on.
+ *
+ * @return
+ * 0 on success or -1 on error
+ */
+int rline_shutdown(struct rline *rline);
+
+/*@}*/
+/* }}}*/
+
+/* Reading and Writing the librline context. {{{*/
+/******************************************************************************/
+/**
+ * @name Reading and Writing the librline context.
+ * These functions are for reading and writing an rline context.
+ */
+/******************************************************************************/
+
+/*@{*/
+
+/**
+ * Read readline history into memory.
+ *
+ * \param rline
+ * The readline context to operate on.
+ *
+ * \param file
+ * The filename to be used that contains the readline history.
+ *
+ * \return
+ * 0 on success or -1 on error
+ */
+int rline_read_history(struct rline *rline, const char *file);
+
+/**
+ * Write readline history to file.
+ *
+ * \param rline
+ * The readline context to operate on.
+ *
+ * \param file
+ * The filename to write the readline history to.
+ *
+ * \return
+ * 0 on success or -1 on error
+ */
+int rline_write_history(struct rline *rline, const char *file);
+
+/*@}*/
+/* }}}*/
+
+/* Functional commands {{{*/
+/******************************************************************************/
+/**
+ * @name Functional commands
+ * These functinos are used to ask the librline context to perform a task.
+ */
+/******************************************************************************/
+
+/*@{*/
+
+/**
+ * Ask librline to change the current prompt that it use's.
+ *
+ * \param rline
+ * The readline context to operate on.
+ *
+ * \param prompt
+ * The prompt to give to readline.
+ *
+ * \return
+ * 0 on success or -1 on error.
+ */
+int rline_set_prompt(struct rline *rline, const char *prompt);
+
+/**
+ * Get the current prompt that readline is using.
+ *
+ * \param rline
+ * The readline context to operate on.
+ *
+ * \param prompt
+ * The prompt that readline is currently using. This will point to the same
+ * memory that readline is using. Do not attempt to free or modify this 
+ * memory directly.
+ *
+ * \return
+ * 0 on success or -1 on error.
+ */
+int rline_get_prompt(struct rline *rline, char **prompt);
+
+/**
+ * Get the current line that readline has.
+ *
+ * \param rline
+ * The readline context to operate on.
+ *
+ * \param prompt
+ * The current line the user has typed in.
+ *
+ * \return
+ * 0 on success or -1 on error.
+ */
+int rline_get_current_line(struct rline *rline, char **current_line);
+
+/**
+ * Clear the data currently entered at the prompt. This function currently
+ * is implemented in such a way that the data is cleared upon the return
+ * of this function. This is so that signal handlers can easily clear the data
+ * without worrying about race conditions.
+ *
+ * \param rline
+ * The readline context to operate on.
+ *
+ * \return
+ * 0 on success or -1 on error.
+ */
+int rline_clear(struct rline *rline);
+
+/**
+ * Add a history entry to the list of history items.
+ *
+ * This function will fail if LINE == NULL.
+ *
+ * \param rline
+ * The readline context to operate on.
+ *
+ * \param line
+ * The line to add to the history.
+ *
+ * \return
+ * 0 on success or -1 on error.
+ */
+int rline_add_history(struct rline *rline, const char *line);
+
+/**
+ * Force the update of readline. This will write the contents of its
+ * current buffer out.
+ *
+ * \param rline
+ * The readline context to operate on.
+ *
+ * \return
+ * 0 on success or -1 on error.
+ */
+int rline_rl_forced_update_display(struct rline *rline);
+
+/**
+ * This tells readline to read from it's input. The caller of this function
+ * must have detected that input was ready on this descritpor. If input is not
+ * ready, this function will hang.
+ *
+ * \param rline
+ * The readline context to operate on.
+ *
+ * \return
+ * 0 on success or -1 on error.
+ */
+int rline_rl_callback_read_char(struct rline *rline);
+
+typedef void (*display_callback) (char **, int, int);
+
+/**
+ * This function will complete the current line that readline has. It will 
+ * get the completions and return them to the display callback to be 
+ * displayed in any way the client sees appropriate. The current readline 
+ * line will be modified after this call if appropriate.
+ *
+ * \param rline
+ * The readline context to operate on.
+ *
+ * \param completions
+ * The array of possible items to complete.
+ *
+ * \param display_cb
+ * This function will be called with a list of possible completions, if there are any.
+ *
+ * \return
+ * 0 on success or -1 on error.
+ */
+int rline_rl_complete(struct rline *rline, char **completions,
+    display_callback display_cb);
+
+/**
+ * This will adjust the size of the PTY that readline is working on, then 
+ * it will alert readline that it will need to be redisplay it's data.
+ * 
+ * \param rline
+ * The readline context to operate on.
+ *
+ * \param rows
+ * The new number of rows the readline pty should be.
+ *
+ * \param cols
+ * The new number of cols the readline pty should be.
+ *
+ * \return
+ * 0 on success or -1 on error.
+ */
+int rline_resize_terminal_and_redisplay(struct rline *rline, int rows,
+        int cols);
+
+/**
+ * Get's the value of rl_completion_query_items.
+ *
+ * \param rline
+ * The readline context to operate on.
+ * 
+ * \param query_items
+ *
+ * \return
+ * The value of rl_completion_query_items, if rline is NULL then -1.
+ */
+int rline_get_rl_completion_query_items(struct rline *rline);
+
 /**
  * This will get the key sequences that readline uses for a certain key.
+ *
+ * \param rline
+ * The readline context to operate on.
  *
  * \param named_function
  * The readline function to get the key sequences for.
@@ -21,12 +296,13 @@
  *
  * \param keyseq
  * A list of key sequences that can be used to map to
- * the named_function the user requested.
+ * the named_function the user requested. 
  *
  * \return
  * 0 on success or -1 on error
  */
-int rline_get_keyseq(const char *named_function, std::list<std::string> &keyseq);
+int rline_get_keyseq(struct rline *rline, const char *named_function,
+        std::list<std::string> &keyseq);
 
 /*@}*/
 /* }}}*/


### PR DESCRIPTION
My removal of the `rline` readline wrapper in #330 has introduced breakage, see #347. I don't currently have the time or the resources to investigate it properly. The suggested fix in #348 involves reintroducing parts of rline, which would defeat the purpose of my initial PR.

I suggest we get back to a known working state, and I'll be more prudent the next time I try to tackle this. Thanks and sorry for the noise.

Fixes #347 
Fixes #348 