### PR TITLE
fix(configure): add int return type to main() for readline test code

### DIFF
--- a/config/readline_check_version.m4
+++ b/config/readline_check_version.m4
@@ -86,7 +86,7 @@ AC_CACHE_VAL(ac_cv_rl_version,
 #include <stdlib.h>
 #include <readline/readline.h>
 
-main()
+int main()
 {
 	FILE *fp;
 	fp = fopen("conftest.rlv", "w");
@@ -183,4 +183,3 @@ if test "x$is_history_header_found" = "xfalse"; then
   fi
 fi
 ])
-


### PR DESCRIPTION
while bottling for macos sequoia, seeing some readline library detection issue, updating the return type to conform with modern c standard.