### PR TITLE
config: fix compilation with GCC14

### DIFF
--- a/config/readline_check_version.m4
+++ b/config/readline_check_version.m4
@@ -86,7 +86,7 @@ AC_CACHE_VAL(ac_cv_rl_version,
 #include <stdlib.h>
 #include <readline/readline.h>
 
-main()
+int main()
 {
 	FILE *fp;
 	fp = fopen("conftest.rlv", "w");


### PR DESCRIPTION
The `main()` function we use in the readline config check does not have a return type declared. This became a hard error starting with GCC14 and thus causes `./configure` to fail.

Fix the issue by declaring the return type.